### PR TITLE
fix metric print

### DIFF
--- a/src/cache_dit/metrics/metrics.py
+++ b/src/cache_dit/metrics/metrics.py
@@ -548,28 +548,28 @@ def entrypoint():
             video_true_info = os.path.basename(video_true)
             video_test_info = os.path.basename(video_test)
 
-            def _logging_msg(value: float, n: int):
+            def _logging_msg(value: float, name, n: int):
                 if value is None or n is None:
                     return
                 msg = (
                     f"{video_true_info} vs {video_test_info}, "
-                    f"Frames: {n}, {metric.upper()}: {value:.5f}"
+                    f"Frames: {n}, {name.upper()}: {value:.5f}"
                 )
                 METRICS_META[msg] = value
                 logger.info(msg)
 
             if metric == "psnr" or metric == "all":
                 video_psnr, n = compute_video_psnr(video_true, video_test)
-                _logging_msg(video_psnr, n)
+                _logging_msg(video_psnr, "psnr", n)
             if metric == "ssim" or metric == "all":
                 video_ssim, n = compute_video_ssim(video_true, video_test)
-                _logging_msg(video_ssim, n)
+                _logging_msg(video_ssim, "ssim", n)
             if metric == "mse" or metric == "all":
                 video_mse, n = compute_video_mse(video_true, video_test)
-                _logging_msg(video_mse, n)
+                _logging_msg(video_mse, "mse", n)
             if metric == "fid" or metric == "all":
                 video_fid, n = FID.compute_video_fid(video_true, video_test)
-                _logging_msg(video_fid, n)
+                _logging_msg(video_fid, "fid", n)
 
     # run selected metrics
     if not DISABLE_VERBOSE:


### PR DESCRIPTION
before

```
INFO 07-23 10:04:19 [metrics.py:500]  vs , Num: 9, ALL: 33.48554
INFO 07-23 10:04:21 [metrics.py:500]  vs , Num: 9, ALL: 0.95216
INFO 07-23 10:04:22 [metrics.py:500]  vs , Num: 9, ALL: 34.50844
INFO 07-23 10:04:34 [metrics.py:500]  vs , Num: 9, ALL: 25.80633
```

after
```
INFO 07-23 10:07:12 [metrics.py:500]  vs , Num: 9, PSNR: 33.48554
INFO 07-23 10:07:15 [metrics.py:500]  vs , Num: 9, SSIM: 0.95216
INFO 07-23 10:07:15 [metrics.py:500]  vs , Num: 9, MSE: 34.50844
INFO 07-23 10:07:27 [metrics.py:500]  vs , Num: 9, FID: 25.80633
```