### PR TITLE
fix: move .to(device) to reduce tp mem 

### DIFF
--- a/examples/parallelism/run_chroma_tp.py
+++ b/examples/parallelism/run_chroma_tp.py
@@ -29,10 +29,10 @@ pipe = ChromaPipeline.from_pretrained(
     torch_dtype=torch.bfloat16,
 )
 
-pipe.to("cuda")
-
 if args.cache or args.parallel_type is not None:
     cachify(args, pipe)
+
+pipe.to(device)
 
 torch.cuda.empty_cache()
 pipe.set_progress_bar_config(disable=rank != 0)

--- a/examples/parallelism/run_flux_tp.py
+++ b/examples/parallelism/run_flux_tp.py
@@ -30,10 +30,12 @@ pipe: FluxPipeline = FluxPipeline.from_pretrained(
         "black-forest-labs/FLUX.1-dev",
     ),
     torch_dtype=torch.bfloat16,
-).to("cuda")
+)
 
 if args.cache or args.parallel_type is not None:
     cachify(args, pipe)
+
+pipe.to(device)
 
 assert isinstance(pipe.transformer, FluxTransformer2DModel)
 

--- a/examples/parallelism/run_kandinsky5_t2v_tp.py
+++ b/examples/parallelism/run_kandinsky5_t2v_tp.py
@@ -34,10 +34,11 @@ model_id = os.environ.get("KANDINSKY5_T2V_DIR", model_id)
 # For now you need to install the latest diffusers as below:
 # pip install git+https://github.com/huggingface/diffusers@main
 pipe = Kandinsky5T2VPipeline.from_pretrained(model_id, torch_dtype=torch.bfloat16)
-pipe = pipe.to("cuda")
 
 if args.cache or args.parallel_type is not None:
     cachify(args, pipe, enable_separate_cfg=not ("nocfg" in model_id))
+
+pipe = pipe.to(device)
 
 torch.cuda.empty_cache()
 


### PR DESCRIPTION
## Motivation

Fix device allocation timing in tensor parallelism examples to reduce memory usage.

## Solution

Move `.to(device)` call after `cachify` in TP examples, so that model weights are sharded before loading to CUDA. This avoids loading the full model to GPU before applying tensor parallelism.
