### PR TITLE
fix qwen-image multi-gpu mismatch

### DIFF
--- a/examples/pipeline/run_qwen_image.py
+++ b/examples/pipeline/run_qwen_image.py
@@ -31,9 +31,14 @@ pipe = QwenImagePipeline.from_pretrained(
 if args.cache:
     cachify(args, pipe)
 
+# When device_map is None, we need to explicitly move the model to GPU
+# or enable CPU offload to avoid running on CPU
 if torch.cuda.device_count() <= 1:
-    # Enable memory savings
+    # Single GPU: use CPU offload for memory efficiency
     pipe.enable_model_cpu_offload()
+elif torch.cuda.device_count() > 1 and pipe.device.type == "cpu":
+    # Multi-GPU but model is on CPU (device_map was None): move to default GPU
+    pipe.to("cuda")
 
 
 positive_magic = {


### PR DESCRIPTION
## Problem

When running on multi-GPU machines (e.g., H100 with >48GB VRAM) without setting `CUDA_VISIBLE_DEVICES`, the model runs on CPU instead of GPU, causing severe performance degradation.

**Root Cause:**
1. `device_map` is set to `None` because [GiB() > 48](cci:1://file:///home/lmsys/bbuf/cache-dit/examples/utils.py:44:0-54:16) (H100 has 80GB)
2. The condition `if torch.cuda.device_count() <= 1` is `False` in multi-GPU environments
3. `pipe.enable_model_cpu_offload()` is NOT called
4. The model remains on CPU after loading

**Performance Impact (H100, 720x720, 50 steps):**
| Scenario | Time | Peak GPU Memory | Status |
|----------|------|-----------------|---------|
| Before fix (multi-GPU visible) | 172.98s | 0.00 GB | ❌ Running on CPU |
| Before fix (CUDA_VISIBLE_DEVICES=0) | 42.94s | ~56 GB | ✅ Running on GPU |
| **After fix (multi-GPU visible)** | **7.20s** | **55.92 GB** | ✅ Running on GPU |

## Solution

Add explicit device management for multi-GPU scenarios:
- **Single GPU**: Use `pipe.enable_model_cpu_offload()` for memory efficiency (existing behavior)
- **Multi-GPU + model on CPU**: Explicitly move pipeline to GPU with `pipe.to("cuda")`

## Testing

Tested on H100 (80GB VRAM) without `CUDA_VISIBLE_DEVICES`:
```bash
python3 run_qwen_image.py --height 720 --width 720 --steps 50 --cache --compile \
  --prompt "A curious raccoon" --model-path /path/to/Qwen-Image --track-memory