### PR TITLE
fix: correct string literal syntax errors in examples

### DIFF
--- a/examples/parallelism/run_hunyuan_image_2.1_cp.py
+++ b/examples/parallelism/run_hunyuan_image_2.1_cp.py
@@ -81,12 +81,9 @@ pipe.set_progress_bar_config(disable=rank != 0)
 
 
 def run_pipe(warmup: bool = False):
-    prompt = "A cute, cartoon-style anthropomorphic penguin plush toy with fluffy fur, "
+    prompt = 'A cute, cartoon-style anthropomorphic penguin plush toy with fluffy fur, standing in a painting studio, wearing a red knitted scarf and a red beret with the word "Tencent" on it, holding a paintbrush with a focused expression as it paints an oil painting of the Mona Lisa, rendered in a photorealistic photographic style.'
     if args.prompt is not None:
         prompt = args.prompt
-    "standing in a painting studio, wearing a red knitted scarf and a red beret with "
-    "the word “Tencent” on it, holding a paintbrush with a focused expression as it "
-    "paints an oil painting of the Mona Lisa, rendered in a photorealistic photographic style."
     image = pipe(
         prompt,
         num_inference_steps=50 if not warmup else 5,

--- a/examples/parallelism/run_hunyuan_image_2.1_tp.py
+++ b/examples/parallelism/run_hunyuan_image_2.1_tp.py
@@ -50,12 +50,9 @@ pipe.set_progress_bar_config(disable=rank != 0)
 
 
 def run_pipe(warmup: bool = False):
-    prompt = "A cute, cartoon-style anthropomorphic penguin plush toy with fluffy fur, "
+    prompt = 'A cute, cartoon-style anthropomorphic penguin plush toy with fluffy fur, standing in a painting studio, wearing a red knitted scarf and a red beret with the word "Tencent" on it, holding a paintbrush with a focused expression as it paints an oil painting of the Mona Lisa, rendered in a photorealistic photographic style.'
     if args.prompt is not None:
         prompt = args.prompt
-    "standing in a painting studio, wearing a red knitted scarf and a red beret with "
-    "the word “Tencent” on it, holding a paintbrush with a focused expression as it "
-    "paints an oil painting of the Mona Lisa, rendered in a photorealistic photographic style."
     image = pipe(
         prompt,
         num_inference_steps=50 if not warmup else 5,

--- a/examples/parallelism/run_wan_cp.py
+++ b/examples/parallelism/run_wan_cp.py
@@ -94,14 +94,9 @@ def run_pipe(warmup: bool = False):
     prompt = "A cat walks on the grass, realistic"
     if args.prompt is not None:
         prompt = args.prompt
-    negative_prompt = "Bright tones, overexposed, static, blurred details, "
+    negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
     if args.negative_prompt is not None:
         negative_prompt = args.negative_prompt
-    "subtitles, style, works, paintings, images, static, overall gray, "
-    "worst quality, low quality, JPEG compression residue, ugly, incomplete, "
-    "extra fingers, poorly drawn hands, poorly drawn faces, deformed, "
-    "disfigured, misshapen limbs, fused fingers, still picture, messy "
-    "background, three legs, many people in the background, walking backwards"
 
     seed = 1234
     generator = torch.Generator(device="cpu").manual_seed(seed)

--- a/examples/parallelism/run_wan_tp.py
+++ b/examples/parallelism/run_wan_tp.py
@@ -94,14 +94,9 @@ def run_pipe(warmup: bool = False):
     prompt = "A cat walks on the grass, realistic"
     if args.prompt is not None:
         prompt = args.prompt
-    negative_prompt = "Bright tones, overexposed, static, blurred details, "
+    negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
     if args.negative_prompt is not None:
         negative_prompt = args.negative_prompt
-    "subtitles, style, works, paintings, images, static, overall gray, "
-    "worst quality, low quality, JPEG compression residue, ugly, incomplete, "
-    "extra fingers, poorly drawn hands, poorly drawn faces, deformed, "
-    "disfigured, misshapen limbs, fused fingers, still picture, messy "
-    "background, three legs, many people in the background, walking backwards"
 
     seed = 1234
     generator = torch.Generator(device="cpu").manual_seed(seed)


### PR DESCRIPTION
Found orphaned string literals in 4 example files where prompt/negative_prompt strings were incorrectly split.

Example before fix:

```shell
negative_prompt = "Bright tones, overexposed, static, blurred details, "
if args.negative_prompt is not None:
    negative_prompt = args.negative_prompt
"subtitles, style, works, paintings, images, static, overall gray, "The strings after line 3 are not assigned to any variable.
```

