### PR TITLE
fix: temp FnB(n>0) workaround for z-image cache w/ cp 

### DIFF
--- a/examples/parallelism/run_zimage_cp.py
+++ b/examples/parallelism/run_zimage_cp.py
@@ -59,7 +59,7 @@ if args.cache or args.parallel_type is not None:
         # Only warmup 4 steps (total 9 steps) for distilled models
         args.max_warmup_steps = min(4, args.max_warmup_steps)
         # Temp workaroud for issue: https://github.com/vipshop/cache-dit/issues/498
-        args.Bn = min(1, args.Bn)
+        args.Bn = max(1, args.Bn)
 
     cachify(args, pipe)
 


### PR DESCRIPTION
#498 