### PR TITLE
Fix get_model_info api 404 when serving with tp/cp 

### DIFF
--- a/src/cache_dit/serve/tp_worker.py
+++ b/src/cache_dit/serve/tp_worker.py
@@ -39,6 +39,10 @@ class TPCoordinator:
         """Expose the underlying model_manager's pipe for compatibility."""
         return self.model_manager.pipe
 
+    def get_model_info(self):
+        """Get model information from the underlying model manager."""
+        return self.model_manager.get_model_info()
+
     def generate(self, request: GenerateRequest) -> GenerateResponse:
         """
         Generate images using TP.


### PR DESCRIPTION
Fix bug

```shell
INFO:     Started server process [3522663]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
INFO 12-04 12:12:52 [model_manager.py:145] Enabling torch.compile
INFO 12-04 12:12:52 [model_manager.py:149] Model loaded successfully
INFO 12-04 12:12:52 [serve.py:276] Model loaded successfully!
INFO 12-04 12:12:52 [serve.py:306] Starting distributed worker (rank 3, tp)
INFO:     127.0.0.1:34884 - "GET /get_model_info HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/applications.py", line 1139, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/applications.py", line 107, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/middleware/exceptions.py", line 63, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/dist-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 716, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 736, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/routing.py", line 290, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 119, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.12/dist-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 105, in app
    response = await f(request)
               ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 385, in app
    raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/fastapi/routing.py", line 284, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/bbuf/cache-dit/src/cache_dit/serve/api_server.py", line 67, in get_model_info
    return JSONResponse(content=_global_model_manager.get_model_info())
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TPCoordinator' object has no attribute 'get_model_info'
```

pr:

<img width="1860" height="724" alt="图片" src="https://github.com/user-attachments/assets/9985a85b-846c-4025-9724-b054e18aac94" />

<img width="1296" height="574" alt="图片" src="https://github.com/user-attachments/assets/040105ae-d847-4a77-b6ec-02d1b8185a07" />
