### PR TITLE
feat: add pipe quant config for serving

### DIFF
--- a/docs/SERVING.md
+++ b/docs/SERVING.md
@@ -182,16 +182,16 @@ cache-dit-serve \
     --model-path black-forest-labs/FLUX.1-dev \
     --cache \
     --quantize \
-    --quantize-config-module /path/to/quantize_config_bitsandbytes.py
+    --pipeline-quant-config-path /path/to/quantize_config_bitsandbytes.py
 ```
 
-To create a custom quantization config, implement `get_quantization_config()` in the Python file specified by `--quantize-config-module`:
+To create a custom pipeline quantization config, implement `get_pipeline_quant_config()` in the Python file specified by `--pipeline-quant-config-path`:
 
 ```python
 import torch
 from diffusers.quantizers import PipelineQuantizationConfig
 
-def get_quantization_config():
+def get_pipeline_quant_config():
     return PipelineQuantizationConfig(
         quant_backend="bitsandbytes_4bit",
         quant_kwargs={

--- a/src/cache_dit/serve/model_manager.py
+++ b/src/cache_dit/serve/model_manager.py
@@ -23,12 +23,12 @@ from diffusers import WanImageToVideoPipeline
 logger = init_logger(__name__)
 
 
-def load_quantization_config(quantize_config_module: str):
-    """Load quantization config from a custom module."""
+def load_pipeline_quant_config(pipeline_quant_config_path: str):
+    """Load pipeline quantization config from a custom module."""
 
     from diffusers.quantizers import PipelineQuantizationConfig
 
-    logger.info(f"Loading quantization config from: {quantize_config_module}")
+    logger.info(f"Loading pipeline quantization config from: {pipeline_quant_config_path}")
 
     try:
         import importlib.util
@@ -36,26 +36,26 @@ def load_quantization_config(quantize_config_module: str):
 
         # Load the custom module
         spec = importlib.util.spec_from_file_location(
-            "quantize_config_module", quantize_config_module
+            "pipeline_quant_config", pipeline_quant_config_path
         )
         if spec is None or spec.loader is None:
-            raise ValueError(f"Cannot load module from {quantize_config_module}")
+            raise ValueError(f"Cannot load module from {pipeline_quant_config_path}")
 
         module = importlib.util.module_from_spec(spec)
-        sys.modules["quantize_config_module"] = module
+        sys.modules[spec.name] = module
         spec.loader.exec_module(module)
 
-        # Get the quantization config from the module
-        if not hasattr(module, "get_quantization_config"):
+        # Get the pipeline quantization config from the module
+        if not hasattr(module, "get_pipeline_quant_config"):
             raise ValueError(
-                f"Module {quantize_config_module} must have a 'get_quantization_config()' function"
+                f"Module {pipeline_quant_config_path} must have a 'get_pipeline_quant_config()' function"
             )
 
-        quantization_config = module.get_quantization_config()
+        quantization_config = module.get_pipeline_quant_config()
 
         if not isinstance(quantization_config, PipelineQuantizationConfig):
             raise ValueError(
-                f"get_quantization_config() must return a PipelineQuantizationConfig object, "
+                f"get_pipeline_quant_config() must return a PipelineQuantizationConfig object, "
                 f"got {type(quantization_config)}"
             )
 
@@ -63,7 +63,7 @@ def load_quantization_config(quantize_config_module: str):
         return quantization_config
 
     except Exception as e:
-        logger.error(f"Failed to load quantization config from {quantize_config_module}: {e}")
+        logger.error(f"Failed to load quantization config from {pipeline_quant_config_path}: {e}")
         raise
 
 
@@ -125,7 +125,8 @@ class ModelManager:
         parallel_args: Optional[Dict[str, Any]] = None,
         attn_backend: Optional[str] = None,
         quantize: bool = False,
-        quantize_config_module: Optional[str] = None,
+        quantize_type: Optional[str] = None,
+        pipeline_quant_config_path: Optional[str] = None,
     ):
         self.model_path = model_path
         self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
@@ -139,7 +140,8 @@ class ModelManager:
         self.parallel_args = parallel_args or {}
         self.attn_backend = attn_backend
         self.quantize = quantize
-        self.quantize_config_module = quantize_config_module
+        self.quantize_type = quantize_type
+        self.pipeline_quant_config_path = pipeline_quant_config_path
         self.pipe = None
         self.warmed_up_shapes = set()
 
@@ -152,12 +154,12 @@ class ModelManager:
         """Load the diffusion model."""
         logger.info(f"Loading model: {self.model_path}")
 
-        # Load quantization config
+        # Load pipeline quantization config
         quantization_config = None
-        if self.quantize and self.quantize_config_module:
-            quantization_config = load_quantization_config(self.quantize_config_module)
+        if self.quantize and self.pipeline_quant_config_path:
+            quantization_config = load_pipeline_quant_config(self.pipeline_quant_config_path)
         elif self.quantize:
-            logger.warning("Quantization enabled but no quantize_config_module provided")
+            logger.warning("Quantization enabled but no pipeline_quant_config_path provided")
 
         if "Wan2.2-I2V-A14B-Diffusers" in self.model_path:
             logger.info("Detected Wan2.2-I2V model, using WanImageToVideoPipeline")
@@ -173,6 +175,12 @@ class ModelManager:
                 torch_dtype=self.torch_dtype,
                 device_map=self.device_map,
                 quantization_config=quantization_config,
+            )
+
+        # TODO(wxy): support quantization by quantize_type
+        if self.quantize and self.quantize_type is not None:
+            logger.warning(
+                f"Quantization type {self.quantize_type} is not supported yet in Serving mode"
             )
 
         cache_config_obj = None

--- a/src/cache_dit/serve/serve.py
+++ b/src/cache_dit/serve/serve.py
@@ -40,10 +40,25 @@ def get_args(
     parser.add_argument("--width", type=int, default=None)
     parser.add_argument("--quantize", "-q", action="store_true", default=False)
     parser.add_argument(
-        "--quantize-config-module",
+        "--quantize-type",
+        type=str,
+        default="float8_weight_only",
+        choices=[
+            "float8",
+            "float8_weight_only",
+            "int8",
+            "int8_weight_only",
+            "int4",
+            "int4_weight_only",
+            "bitsandbytes_4bit",
+            "bnb_4bit",
+        ],
+    )
+    parser.add_argument(
+        "--pipeline-quant-config-path",
         type=str,
         default=None,
-        help="Path to custom Python module that provides get_quantization_config() function",
+        help="Path to custom Python module that provides get_pipeline_quant_config() function",
     )
     parser.add_argument(
         "--parallel-type",
@@ -124,7 +139,11 @@ def get_args(
     )
     parser.add_argument("--profile-with-stack", action="store_true", default=True)
     parser.add_argument("--profile-record-shapes", action="store_true", default=True)
-    return parser.parse_args() if parse else parser
+    args_or_parser = parser.parse_args() if parse else parser
+    if parse:
+        if args_or_parser.quantize_type == "bnb_4bit":
+            args_or_parser.quantize_type = "bitsandbytes_4bit"
+    return args_or_parser
 
 
 def parse_args():
@@ -176,6 +195,10 @@ def parse_args():
     )
 
     args = parser.parse_args()
+
+    # Handle quantize_type alias
+    if hasattr(args, "quantize_type") and args.quantize_type == "bnb_4bit":
+        args.quantize_type = "bitsandbytes_4bit"
 
     # Ensure model_path is required
     if not args.model_path:
@@ -254,7 +277,8 @@ def launch_server(args=None):
         parallel_args=parallel_args,
         attn_backend=args.attn,
         quantize=args.quantize,
-        quantize_config_module=args.quantize_config_module,
+        quantize_type=args.quantize_type,
+        pipeline_quant_config_path=args.pipeline_quant_config_path,
     )
 
     logger.info("Loading model...")


### PR DESCRIPTION
## Summary

This PR introduces a flexible quantization configuration solution that allows users to provide custom quantization configs via Python modules, replacing the previous hardcoded approach.

## Motivation

Quantization configurations are highly diverse and model-specific. It's impractical for the framework to maintain hardcoded configs for all models and quantization methods. By allowing users to provide custom configuration modules, we give them full control over quantization parameters while keeping the core codebase clean and maintainable.

## Usage
#### Server
```bash
cache-dit-serve \
    --model-path black-forest-labs/FLUX.1-dev \
    --cache \
    --quantize \
    --pipeline-quant-config-path /path/to/quantize_config.py
```
```py
### /path/to/quantize_config.py ###
import torch
from diffusers.quantizers import PipelineQuantizationConfig


def get_pipeline_quant_config():
    """Return a PipelineQuantizationConfig for bitsandbytes 4-bit quantization.
    
    This function must be implemented and return a PipelineQuantizationConfig object.
    """
    quantization_config = PipelineQuantizationConfig(
        quant_backend="bitsandbytes_4bit",
        quant_kwargs={
            "load_in_4bit": True,
            "bnb_4bit_quant_type": "nf4",
            "bnb_4bit_compute_dtype": torch.bfloat16,
        },
        components_to_quantize=["text_encoder", "transformer"],
    )
    
    return quantization_config
```
#### Client
```py
import requests
import base64
from PIL import Image
from io import BytesIO

resolutions = [
    (1024, 1024),
]

prompt = "A futuristic cityscape at night with neon lights and flying vehicles, cyberpunk style"

for width, height in resolutions:
    response = requests.post(
        "http://localhost:8000/generate",
        json={
            "prompt": prompt,
            "width": width,
            "height": height,
            "num_inference_steps": 50
        }
    )
    
    result = response.json()
    img_data = base64.b64decode(result["images"][0])
    img = Image.open(BytesIO(img_data))
    
    output_filename = f"output_{width}x{height}.png"
    img.save(output_filename)
```

#### Result
<img width="256" height="256" alt="image" src="https://github.com/user-attachments/assets/5a2d0868-f603-4d52-acb1-5ffba529b621" />
