### PR TITLE
[chore] Improve error_logging in serving tp_worker.py

### DIFF
--- a/src/cache_dit/serve/tp_worker.py
+++ b/src/cache_dit/serve/tp_worker.py
@@ -155,9 +155,7 @@ def run_tp_worker(model_manager, rank: int):
                 dist.destroy_process_group()
                 break
             else:
-                logger.exception(
-                    f"TP worker {rank} runtime error: {type(e).__name__}: {e}"
-                )
+                logger.exception(f"TP worker {rank} runtime error: {type(e).__name__}: {e}")
                 time.sleep(0.1)
         except Exception as e:
             logger.exception(f"TP worker {rank} error: {type(e).__name__}: {e}")


### PR DESCRIPTION
```shell
 torchrun --nproc_per_node=2 -m cache_dit.serve.serve \
    --model-path Tongyi-MAI/Z-Image-Turbo \
    --cache \
    --attn _flash_3 \
    --parallel-type tp
```

When we `pip3 install diffusers git+https://github.com/huggingface/diffusers.git` and didn't do this change:

<img width="2098" height="1036" alt="1bea3130-5f5d-4831-922a-04c6871137f1" src="https://github.com/user-attachments/assets/c658ebeb-2e34-445a-9aaf-aa0cb9c33c34" />

The error happed, and server error log is:

```shell
lifting a w...', seed=42
INFO 12-26 10:04:38 [model_manager.py:415] tp mode: using fixed seed 42
INFO 12-26 10:04:38 [model_manager.py:425] generation: prompt='A [SUBJECT] is crouching on the beach, lifting a w...', seed=42
/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py:4876: UserWarning: barrier(): using the device under current context. You can specify `device_id` in `init_process_group` to mute this warning.
  warnings.warn(  # warn only once
  0%|                                                                                                                      | 0/8 [00:00<?, ?it/s]
ERROR:cache_dit.serve.tp_worker:TP worker 1 error: ValueError: not enough values to unpack (expected at least 2, got 1)
  0%|                                                                                                                      | 0/8 [00:00<?, ?it/s]
ERROR 12-26 10:04:38 [api_server.py:117] Error generating image: ValueError: not enough values to unpack (expected at least 2, got 1)
INFO:     127.0.0.1:40330 - "POST /generate HTTP/1.1" 500 Internal Server Error
```

We can't find the error stack trace due to the `logger.error`.

With pr change:

<img width="1598" height="814" alt="图片" src="https://github.com/user-attachments/assets/82b445a1-5fea-413f-80a2-293b119b6386" />

We can get real error stack trace now.
