### PR TITLE
[Bug] Apply --attn backend in single-GPU examples

### DIFF
--- a/examples/utils.py
+++ b/examples/utils.py
@@ -1186,7 +1186,9 @@ def maybe_apply_optimization(
                 return
             if hasattr(module, "set_attention_backend"):
                 module.set_attention_backend(args.attn)
-                logger.info(f"Set attention backend to {args.attn} for module: {module.__class__.__name__}.")
+                logger.info(
+                    f"Set attention backend to {args.attn} for module: {module.__class__.__name__}."
+                )
             else:
                 logger.warning(
                     "--attn was provided but module does not support set_attention_backend: "


### PR DESCRIPTION
baseline

```markdown
cd examples
python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 1024 --width 1024 --compile
INFO 12-30 03:02:50 [base.py:290] - Inference Time: 1.08s

python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 2048 --width 2048 --compile
INFO 12-30 03:05:41 [base.py:290] - Inference Time: 6.66s
```

add `--attn _flash_3`

## main

```markdown
cd examples
python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 1024 --width 1024 --compile --attn _flash_3
INFO 12-30 05:03:24 [base.py:290] - Inference Time: 1.08s

python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 2048 --width 2048 --compile --attn _flash_3
INFO 12-30 05:06:33 [base.py:290] - Inference Time: 6.66s
```

## pr

```markdown
cd examples
python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 1024 --width 1024 --compile --attn _flash_3
INFO 12-30 03:08:26 [base.py:290] - Inference Time: 0.97s

python3 generate.py zimage --prompt "A cat is sitting on a chair" --height 2048 --width 2048 --compile --attn _flash_3
INFO 12-30 05:18:57 [base.py:290] - Inference Time: 5.04s
```





