### PR TITLE
Serving: Align inference time format with LightX2V (timezone-aware)

### DIFF
--- a/src/cache_dit/serve/client.py
+++ b/src/cache_dit/serve/client.py
@@ -52,6 +52,11 @@ def generate_image(
     if result.get("time_cost"):
         print(f"Time cost: {result['time_cost']:.2f}s")
 
+    if result.get("inference_start_time"):
+        print(f"Inference start time: {result['inference_start_time']}")
+    if result.get("inference_end_time"):
+        print(f"Inference end time: {result['inference_end_time']}")
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Cache-DiT serving client")


### PR DESCRIPTION
Align with https://github.com/ModelTC/LightX2V/blob/main/lightx2v/deploy/common/utils.py#L16 

```shell
 torchrun --nproc_per_node=1 -m cache_dit.serve.serve --model-path Qwen/Qwen-Image-2512 --cache --attn _flash_3 --compile
```

```shell
python3 test_inference_timestamps.py

start 2026-01-04 07:47:31+00:00
end 2026-01-04 07:47:32+00:00
time_cost 1.3642690181732178
```

