### PR TITLE
[Doc] Profiling doc match new generate.py

### DIFF
--- a/examples/base.py
+++ b/examples/base.py
@@ -549,7 +549,9 @@ class Example:
         # actual inference
         model_tag = self.args.example if self.args.example is not None else "None"
         if self.args.profile:
-            profiler = create_profiler_from_args(self.args, profile_name=f"{model_tag}_profile")
+            requested_profile_name = getattr(self.args, "profile_name", None)
+            profile_name = requested_profile_name or f"{model_tag}_profile"
+            profiler = create_profiler_from_args(self.args, profile_name=profile_name)
             with profiler:
                 for _ in range(self.args.repeat):
                     input_kwargs = self.new_generator(input_kwargs, self.args)


### PR DESCRIPTION
Some example:

```shell
 cache-dit  nsys profile \
  --trace=cuda,nvtx,osrt \
  --force-overwrite=true \
  --delay 10 \
  --duration 30 \
  -o cache_dit_flux_infer \
  python3 generate.py flux --steps 28 --warmup 0 --repeat 1
^C^C^C^C^C^C^C^C^C#                                                                                                                              
➜  cache-dit cd examples 
➜  examples nsys profile \                          
  --trace=cuda,nvtx,osrt \
  --force-overwrite=true \
  --delay 10 \
  --duration 30 \
  -o cache_dit_flux_infer \
  python3 generate.py flux --steps 28 --warmup 0 --repeat 1
INFO 01-10 04:05:16 [generate.py:64] Running example with the following arguments:
INFO 01-10 04:05:16 [generate.py:66] - model_path: None
INFO 01-10 04:05:16 [generate.py:66] - controlnet_path: None
INFO 01-10 04:05:16 [generate.py:66] - lora_path: None
INFO 01-10 04:05:16 [generate.py:66] - transformer_path: None
INFO 01-10 04:05:16 [generate.py:66] - image_path: None
INFO 01-10 04:05:16 [generate.py:66] - mask_image_path: None
INFO 01-10 04:05:16 [generate.py:66] - config_path: None
INFO 01-10 04:05:16 [generate.py:66] - prompt: None
INFO 01-10 04:05:16 [generate.py:66] - negative_prompt: None
INFO 01-10 04:05:16 [generate.py:66] - num_inference_steps: 28
INFO 01-10 04:05:16 [generate.py:66] - warmup: 0
INFO 01-10 04:05:16 [generate.py:66] - repeat: 1
INFO 01-10 04:05:16 [generate.py:66] - height: None
INFO 01-10 04:05:16 [generate.py:66] - width: None
INFO 01-10 04:05:16 [generate.py:66] - seed: None
INFO 01-10 04:05:16 [generate.py:66] - num_frames: None
INFO 01-10 04:05:16 [generate.py:66] - save_path: None
INFO 01-10 04:05:16 [generate.py:66] - cache: False
INFO 01-10 04:05:16 [generate.py:66] - cache_summary: False
INFO 01-10 04:05:16 [generate.py:66] - Fn_compute_blocks: 1
INFO 01-10 04:05:16 [generate.py:66] - Bn_compute_blocks: 0
INFO 01-10 04:05:16 [generate.py:66] - residual_diff_threshold: 0.24
INFO 01-10 04:05:16 [generate.py:66] - max_warmup_steps: 8
INFO 01-10 04:05:16 [generate.py:66] - warmup_interval: 1
INFO 01-10 04:05:16 [generate.py:66] - max_cached_steps: -1
INFO 01-10 04:05:16 [generate.py:66] - max_continuous_cached_steps: 3
INFO 01-10 04:05:16 [generate.py:66] - taylorseer: False
INFO 01-10 04:05:16 [generate.py:66] - taylorseer_order: 1
INFO 01-10 04:05:16 [generate.py:66] - steps_mask: False
INFO 01-10 04:05:16 [generate.py:66] - mask_policy: None
INFO 01-10 04:05:16 [generate.py:66] - quantize: False
INFO 01-10 04:05:16 [generate.py:66] - quantize_type: None
INFO 01-10 04:05:16 [generate.py:66] - quantize_text_encoder: False
INFO 01-10 04:05:16 [generate.py:66] - quantize_text_type: None
INFO 01-10 04:05:16 [generate.py:66] - quantize_controlnet: False
INFO 01-10 04:05:16 [generate.py:66] - quantize_controlnet_type: None
INFO 01-10 04:05:16 [generate.py:66] - parallel_type: None
INFO 01-10 04:05:16 [generate.py:66] - parallel_vae: False
INFO 01-10 04:05:16 [generate.py:66] - parallel_text_encoder: False
INFO 01-10 04:05:16 [generate.py:66] - parallel_controlnet: False
INFO 01-10 04:05:16 [generate.py:66] - attn: None
INFO 01-10 04:05:16 [generate.py:66] - ulysses_anything: False
INFO 01-10 04:05:16 [generate.py:66] - ulysses_float8: False
INFO 01-10 04:05:16 [generate.py:66] - ulysses_async: False
INFO 01-10 04:05:16 [generate.py:66] - cpu_offload: False
INFO 01-10 04:05:16 [generate.py:66] - sequential_cpu_offload: False
INFO 01-10 04:05:16 [generate.py:66] - device_map_balance: False
INFO 01-10 04:05:16 [generate.py:66] - vae_tiling: False
INFO 01-10 04:05:16 [generate.py:66] - vae_slicing: False
INFO 01-10 04:05:16 [generate.py:66] - compile: False
INFO 01-10 04:05:16 [generate.py:66] - compile_repeated_blocks: False
INFO 01-10 04:05:16 [generate.py:66] - compile_vae: False
INFO 01-10 04:05:16 [generate.py:66] - compile_text_encoder: False
INFO 01-10 04:05:16 [generate.py:66] - compile_controlnet: False
INFO 01-10 04:05:16 [generate.py:66] - max_autotune: False
INFO 01-10 04:05:16 [generate.py:66] - track_memory: False
INFO 01-10 04:05:16 [generate.py:66] - profile: False
INFO 01-10 04:05:16 [generate.py:66] - profile_name: None
INFO 01-10 04:05:16 [generate.py:66] - profile_dir: None
INFO 01-10 04:05:16 [generate.py:66] - profile_activities: ['CPU', 'GPU']
INFO 01-10 04:05:16 [generate.py:66] - profile_with_stack: True
INFO 01-10 04:05:16 [generate.py:66] - profile_record_shapes: True
INFO 01-10 04:05:16 [generate.py:66] - disable_fuse_lora: None
INFO 01-10 04:05:16 [generate.py:66] - task: generate
INFO 01-10 04:05:16 [generate.py:66] - example: flux
Loading pipeline components...:   0%|          | 0/7 [00:00<?, ?it/s]`torch_dtype` is deprecated! Use `dtype` instead!
Loading pipeline components...:  14%|█▍        | 1/7 [00:00<00:01,  5.95it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00, 114.40it/s]t/s]
Loading checkpoint shards: 100%|██████████| 3/3 [00:00<00:00, 34.42it/s]
Loading pipeline components...: 100%|██████████| 7/7 [00:00<00:00, 12.76it/s]
Collecting data...
100%|██████████| 28/28 [00:05<00:00,  5.38it/s]
INFO 01-10 04:05:34 [base.py:607] ----------------------------------------------------------------------------------------------------
INFO 01-10 04:05:34 [base.py:385] 🤖 Example Init Config Summary:
INFO 01-10 04:05:34 [base.py:408] - Model: black-forest-labs/FLUX.1-dev
INFO 01-10 04:05:34 [base.py:408] - Task Type: T2I - Text to Image
INFO 01-10 04:05:34 [base.py:408] - Torch Dtype: torch.bfloat16
INFO 01-10 04:05:34 [base.py:408] - LoRA Weights: None
INFO 01-10 04:05:34 [base.py:202] 🤖 Example Input Summary:
INFO 01-10 04:05:34 [base.py:202] - prompt: A cat holding a sign that says hello world
INFO 01-10 04:05:34 [base.py:202] - height: 1024
INFO 01-10 04:05:34 [base.py:202] - width: 1024
INFO 01-10 04:05:34 [base.py:202] - num_inference_steps: 28
INFO 01-10 04:05:34 [base.py:202] - generator: device cpu, seed 0
INFO 01-10 04:05:34 [base.py:297] 🤖 Example Output Summary:
INFO 01-10 04:05:34 [base.py:313] - Model: flux
INFO 01-10 04:05:34 [base.py:313] - Optimization: C0_Q0_NONE
INFO 01-10 04:05:34 [base.py:313] - Device: NVIDIA H100 80GB HBM3 x 1
INFO 01-10 04:05:34 [base.py:313] - Load Time: 0.76s
INFO 01-10 04:05:34 [base.py:313] - Inference Time: 6.69s
INFO 01-10 04:05:34 [base.py:236] Image saved to flux.1024x1024.C0_Q0_NONE.png
INFO 01-10 04:05:34 [base.py:618] ----------------------------------------------------------------------------------------------------
Generating '/tmp/nsys-report-653f.qdstrm'
[1/1] [========================100%] cache_dit_flux_infer.nsys-rep
Generated:
        /home/lmsys/bbuf/cache-dit/examples/cache_dit_flux_infer.nsys-rep
➜  examples ls -lh cache_dit_flux_infer.nsys-rep                                
-rw-rw-r-- 1 root root 6.3M Jan 10 04:05 cache_dit_flux_infer.nsys-rep
➜  examples python3 generate.py flux --profile --steps 3
INFO 01-10 04:08:11 [generate.py:64] Running example with the following arguments:
INFO 01-10 04:08:11 [generate.py:66] - model_path: None
INFO 01-10 04:08:11 [generate.py:66] - controlnet_path: None
INFO 01-10 04:08:11 [generate.py:66] - lora_path: None
INFO 01-10 04:08:11 [generate.py:66] - transformer_path: None
INFO 01-10 04:08:11 [generate.py:66] - image_path: None
INFO 01-10 04:08:11 [generate.py:66] - mask_image_path: None
INFO 01-10 04:08:11 [generate.py:66] - config_path: None
INFO 01-10 04:08:11 [generate.py:66] - prompt: None
INFO 01-10 04:08:11 [generate.py:66] - negative_prompt: None
INFO 01-10 04:08:11 [generate.py:66] - num_inference_steps: 3
INFO 01-10 04:08:11 [generate.py:66] - warmup: 1
INFO 01-10 04:08:11 [generate.py:66] - repeat: 1
INFO 01-10 04:08:11 [generate.py:66] - height: None
INFO 01-10 04:08:11 [generate.py:66] - width: None
INFO 01-10 04:08:11 [generate.py:66] - seed: None
INFO 01-10 04:08:11 [generate.py:66] - num_frames: None
INFO 01-10 04:08:11 [generate.py:66] - save_path: None
INFO 01-10 04:08:11 [generate.py:66] - cache: False
INFO 01-10 04:08:11 [generate.py:66] - cache_summary: False
INFO 01-10 04:08:11 [generate.py:66] - Fn_compute_blocks: 1
INFO 01-10 04:08:11 [generate.py:66] - Bn_compute_blocks: 0
INFO 01-10 04:08:11 [generate.py:66] - residual_diff_threshold: 0.24
INFO 01-10 04:08:11 [generate.py:66] - max_warmup_steps: 8
INFO 01-10 04:08:11 [generate.py:66] - warmup_interval: 1
INFO 01-10 04:08:11 [generate.py:66] - max_cached_steps: -1
INFO 01-10 04:08:11 [generate.py:66] - max_continuous_cached_steps: 3
INFO 01-10 04:08:11 [generate.py:66] - taylorseer: False
INFO 01-10 04:08:11 [generate.py:66] - taylorseer_order: 1
INFO 01-10 04:08:11 [generate.py:66] - steps_mask: False
INFO 01-10 04:08:11 [generate.py:66] - mask_policy: None
INFO 01-10 04:08:11 [generate.py:66] - quantize: False
INFO 01-10 04:08:11 [generate.py:66] - quantize_type: None
INFO 01-10 04:08:11 [generate.py:66] - quantize_text_encoder: False
INFO 01-10 04:08:11 [generate.py:66] - quantize_text_type: None
INFO 01-10 04:08:11 [generate.py:66] - quantize_controlnet: False
INFO 01-10 04:08:11 [generate.py:66] - quantize_controlnet_type: None
INFO 01-10 04:08:11 [generate.py:66] - parallel_type: None
INFO 01-10 04:08:11 [generate.py:66] - parallel_vae: False
INFO 01-10 04:08:11 [generate.py:66] - parallel_text_encoder: False
INFO 01-10 04:08:11 [generate.py:66] - parallel_controlnet: False
INFO 01-10 04:08:11 [generate.py:66] - attn: None
INFO 01-10 04:08:11 [generate.py:66] - ulysses_anything: False
INFO 01-10 04:08:11 [generate.py:66] - ulysses_float8: False
INFO 01-10 04:08:11 [generate.py:66] - ulysses_async: False
INFO 01-10 04:08:11 [generate.py:66] - cpu_offload: False
INFO 01-10 04:08:11 [generate.py:66] - sequential_cpu_offload: False
INFO 01-10 04:08:11 [generate.py:66] - device_map_balance: False
INFO 01-10 04:08:11 [generate.py:66] - vae_tiling: False
INFO 01-10 04:08:11 [generate.py:66] - vae_slicing: False
INFO 01-10 04:08:11 [generate.py:66] - compile: False
INFO 01-10 04:08:11 [generate.py:66] - compile_repeated_blocks: False
INFO 01-10 04:08:11 [generate.py:66] - compile_vae: False
INFO 01-10 04:08:11 [generate.py:66] - compile_text_encoder: False
INFO 01-10 04:08:11 [generate.py:66] - compile_controlnet: False
INFO 01-10 04:08:11 [generate.py:66] - max_autotune: False
INFO 01-10 04:08:11 [generate.py:66] - track_memory: False
INFO 01-10 04:08:11 [generate.py:66] - profile: True
INFO 01-10 04:08:11 [generate.py:66] - profile_name: None
INFO 01-10 04:08:11 [generate.py:66] - profile_dir: None
INFO 01-10 04:08:11 [generate.py:66] - profile_activities: ['CPU', 'GPU']
INFO 01-10 04:08:11 [generate.py:66] - profile_with_stack: True
INFO 01-10 04:08:11 [generate.py:66] - profile_record_shapes: True
INFO 01-10 04:08:11 [generate.py:66] - disable_fuse_lora: None
INFO 01-10 04:08:11 [generate.py:66] - task: generate
INFO 01-10 04:08:11 [generate.py:66] - example: flux
Loading pipeline components...:   0%|                                                                                      | 0/7 [00:00<?, ?it/s]You set `add_prefix_space`. The tokenizer needs to be converted from the slow tokenizers
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 75.61it/s]
`torch_dtype` is deprecated! Use `dtype` instead!                                                                          | 0/3 [00:00<?, ?it/s]
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 179.78it/s]
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00, 19.11it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  5.44it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.13it/s]
INFO 01-10 04:08:27 [base.py:560] Profiler traces saved to: /tmp/cache_dit_profiles/flux_profile.trace.json.gz
INFO 01-10 04:08:27 [base.py:607] ----------------------------------------------------------------------------------------------------
INFO 01-10 04:08:27 [base.py:385] 🤖 Example Init Config Summary:
INFO 01-10 04:08:27 [base.py:408] - Model: black-forest-labs/FLUX.1-dev
INFO 01-10 04:08:27 [base.py:408] - Task Type: T2I - Text to Image
INFO 01-10 04:08:27 [base.py:408] - Torch Dtype: torch.bfloat16
INFO 01-10 04:08:27 [base.py:408] - LoRA Weights: None
INFO 01-10 04:08:27 [base.py:202] 🤖 Example Input Summary:
INFO 01-10 04:08:27 [base.py:202] - prompt: A cat holding a sign that says hello world
INFO 01-10 04:08:27 [base.py:202] - height: 1024
INFO 01-10 04:08:27 [base.py:202] - width: 1024
INFO 01-10 04:08:27 [base.py:202] - num_inference_steps: 3
INFO 01-10 04:08:27 [base.py:202] - generator: device cpu, seed 0
INFO 01-10 04:08:27 [base.py:297] 🤖 Example Output Summary:
INFO 01-10 04:08:27 [base.py:313] - Model: flux
INFO 01-10 04:08:27 [base.py:313] - Optimization: C0_Q0_NONE
INFO 01-10 04:08:27 [base.py:313] - Device: NVIDIA H100 80GB HBM3 x 1
INFO 01-10 04:08:27 [base.py:313] - Load Time: 0.56s
INFO 01-10 04:08:27 [base.py:313] - Warmup Time: 8.65s
INFO 01-10 04:08:27 [base.py:313] - Inference Time: 6.73s
INFO 01-10 04:08:27 [base.py:236] Image saved to flux.1024x1024.C0_Q0_NONE.png
INFO 01-10 04:08:27 [base.py:618] ----------------------------------------------------------------------------------------------------
```