### PR TITLE
[chore] Align torch generator with example

### DIFF
--- a/src/cache_dit/serve/model_manager.py
+++ b/src/cache_dit/serve/model_manager.py
@@ -587,7 +587,7 @@ class ModelManager:
 
         seed = request.seed
         if seed is None and self.parallel_type in ["tp", "ulysses", "ring"]:
-            seed = 42
+            seed = 0
             logger.info(f"{self.parallel_type} mode: using fixed seed {seed}")
 
         if is_image2video_mode:

--- a/tests/serving/test_flux2_image_edit_serving.py
+++ b/tests/serving/test_flux2_image_edit_serving.py
@@ -29,7 +29,7 @@ def call_api(prompt, image_urls=None, name="test", **kwargs):
         "height": kwargs.get("height", 1024),
         "num_inference_steps": kwargs.get("num_inference_steps", 50),
         "guidance_scale": kwargs.get("guidance_scale", 4.0),
-        "seed": kwargs.get("seed", 42),
+        "seed": kwargs.get("seed", 0),
     }
 
     if "output_format" in kwargs:

--- a/tests/serving/test_flux2_turbo_lora_serving.py
+++ b/tests/serving/test_flux2_turbo_lora_serving.py
@@ -43,7 +43,7 @@ def call_api(prompt, name="flux2_turbo", **kwargs):
         "num_inference_steps": kwargs.get("num_inference_steps", 8),
         "guidance_scale": kwargs.get("guidance_scale", 2.5),
         "sigmas": kwargs.get("sigmas", TURBO_SIGMAS),
-        "seed": kwargs.get("seed", 42),
+        "seed": kwargs.get("seed", 0),
         "num_images": kwargs.get("num_images", 1),
     }
 

--- a/tests/serving/test_inference_timestamps.py
+++ b/tests/serving/test_inference_timestamps.py
@@ -13,7 +13,7 @@ def _call_generate_api(**overrides):
         "height": overrides.get("height", 1024),
         "num_inference_steps": overrides.get("num_inference_steps", 8),
         "guidance_scale": overrides.get("guidance_scale", 1.0),
-        "seed": overrides.get("seed", 42),
+        "seed": overrides.get("seed", 0),
         "output_format": "path",
     }
 

--- a/tests/serving/test_ltx2_image2video.py
+++ b/tests/serving/test_ltx2_image2video.py
@@ -133,7 +133,7 @@ def test_ltx2_image2video():
             negative_prompt=negative_prompt,
             image_url=image_url,
             name="ltx2_base_i2v",
-            seed=42,
+            seed=0,
             width=768,
             height=512,
             num_frames=121,

--- a/tests/serving/test_ltx2_text2video.py
+++ b/tests/serving/test_ltx2_text2video.py
@@ -121,7 +121,7 @@ def test_ltx2_text2video():
             prompt=prompt,
             negative_prompt=negative_prompt,
             name="ltx2_base_t2v",
-            seed=42,
+            seed=0,
             width=768,
             height=512,
             num_frames=121,

--- a/tests/serving/test_qwen_image_lightning_serving.py
+++ b/tests/serving/test_qwen_image_lightning_serving.py
@@ -39,7 +39,7 @@ def call_api(prompt, name="test", **kwargs):
         "height": kwargs.get("height", 1024),
         "num_inference_steps": kwargs.get("num_inference_steps", 8),
         "guidance_scale": kwargs.get("guidance_scale", 1.0),
-        "seed": kwargs.get("seed", 42),
+        "seed": kwargs.get("seed", 0),
         "num_images": kwargs.get("num_images", 1),
     }
 
@@ -127,7 +127,7 @@ def test_basic_4steps():
         name="qwen_lightning_4steps",
         num_inference_steps=4,
         guidance_scale=1.0,
-        seed=42,
+        seed=0,
     )
 
 

--- a/tests/serving/test_wan_t2v_serving.py
+++ b/tests/serving/test_wan_t2v_serving.py
@@ -63,7 +63,7 @@ def test_custom_prompt():
     return call_api(
         prompt="A beautiful sunset over the ocean with waves crashing on the shore",
         name="wan_t2v_sunset",
-        seed=42,
+        seed=0,
     )
 
 


### PR DESCRIPTION
When we use this clinet script to generate image with FLUX2, bug happens:

```python

import os
import requests
import base64
from PIL import Image
from io import BytesIO


def call_api(prompt, image_urls=None, name="test", **kwargs):
    host = os.environ.get("CACHE_DIT_HOST", "localhost")
    port = int(os.environ.get("CACHE_DIT_PORT", 8000))
    url = f"http://{host}:{port}/generate"

    payload = {
        "prompt": prompt,
        "width": kwargs.get("width", 1024),
        "height": kwargs.get("height", 1024),
        "num_inference_steps": kwargs.get("num_inference_steps", 50),
        "guidance_scale": kwargs.get("guidance_scale", 4.0),
        "seed": kwargs.get("seed", 0),
    }

    if "output_format" in kwargs:
        payload["output_format"] = kwargs["output_format"]
    if "output_dir" in kwargs:
        payload["output_dir"] = kwargs["output_dir"]

    if image_urls:
        payload["image_urls"] = image_urls

    response = requests.post(url, json=payload, timeout=300)
    response.raise_for_status()
    result = response.json()
    assert "images" in result and len(result["images"]) > 0, "No images in response"

    if payload.get("output_format", "base64") == "path":
        filename = result["images"][0]
        assert os.path.exists(filename)
        img = Image.open(filename)
        print(f"Saved: {filename} ({img.size[0]}x{img.size[1]})")
        return filename
    else:
        img_data = base64.b64decode(result["images"][0])
        img = Image.open(BytesIO(img_data))

        filename = f"{name}.png"
        img.save(filename)

        print(f"Saved: {filename} ({img.size[0]}x{img.size[1]})")
        return filename


def test_single():
    return call_api(
        prompt="生成这个房子夜晚的样子",
        image_urls=["https://files.mdnice.com/user/59/16cdc7ec-ebec-423a-a8d2-e21e11cfd0d4.jpg"],
        name="single_edit",
        output_format="path",
        output_dir="outputs_test",
        num_inference_steps=28,
        guidance_scale=4.0,
        seed=42,
    )

```

origin image:

<img width="1024" height="1024" alt="1280X1280" src="https://github.com/user-attachments/assets/4ac86721-3a54-4431-a151-947d3000cd05" />

generated image:

<img width="954" height="848" alt="图片" src="https://github.com/user-attachments/assets/27365f28-300a-4f22-ba7e-5eaf89d173b0" />


The prompt "生成这个房子夜晚的样子" is not followed by FLUX.2.dev

But when I use `torchrun --nproc_per_node=4 generate.py flux2 --parallel ulysses --promp "生成这个房子夜晚的样子" --height 1024 --width 1024 --parallel-text-encoder --cache --image-path /home/lmsys/bbuf/1280X1280.PNG --num_inference_steps 28`  command, the generated image is ok.

<img width="850" height="840" alt="图片" src="https://github.com/user-attachments/assets/5658d7a4-0426-4dc8-b537-4ddd03861831" />


Debug for a long time, I found the reason is the unaligned random generator. now with the `seed=0`, we can get the correct image too.

```python
def test_single():
    return call_api(
        prompt="生成这个房子夜晚的样子",
        image_urls=["https://files.mdnice.com/user/59/16cdc7ec-ebec-423a-a8d2-e21e11cfd0d4.jpg"],
        name="single_edit",
        output_format="path",
        output_dir="outputs_test",
        num_inference_steps=28,
        guidance_scale=4.0,
        seed=0,
    )
```

<img width="850" height="840" alt="图片" src="https://github.com/user-attachments/assets/5658d7a4-0426-4dc8-b537-4ddd03861831" />

