### PR TITLE
fix selected metrics print

### DIFF
--- a/src/cache_dit/metrics/metrics.py
+++ b/src/cache_dit/metrics/metrics.py
@@ -1074,6 +1074,10 @@ def entrypoint():
                 if metric.upper() in key or metric.lower() in key:
                     selected_items[key] = METRICS_META[key]
 
+            # skip unselected metric
+            if len(selected_items) == 0:
+                continue
+
             reverse = (
                 True
                 if metric.lower()


### PR DESCRIPTION
fix print when metrics is not "all":

1. let `selected_metrics = METRICS_CHOICES = ["lpips", "psnr", ...]`
2. `METRICS_META.keys() = ["lpips]`
3. crash when try to print `psnr`

<img width="666" height="104" alt="image" src="https://github.com/user-attachments/assets/efebc976-1d80-4194-842c-3cba13d40936" />

reproduce:

```bash
cache-dit-metrics-cli \
  ssim lpips --summary --gen-markdown-table \
  --ref-img-dir ./ref_images \
  --img-source-dir ./our_images \
```

since:

<img width="907" height="564" alt="image" src="https://github.com/user-attachments/assets/68f87515-7c9c-4386-8e52-a1767cb31a4d" />

