### PR TITLE
[chore] Fix FLUX2 Ulysses Anything NCCL Hang

### DIFF
--- a/src/cache_dit/parallelism/attention/_distributed_primitives.py
+++ b/src/cache_dit/parallelism/attention/_distributed_primitives.py
@@ -1,4 +1,3 @@
-import functools
 from typing import Tuple, List, Callable, Optional
 
 import torch


### PR DESCRIPTION
```shell
torchrun --nproc_per_node=4 -m cache_dit.serve.serve --model-path  black-forest-labs/FLUX.2-dev --parallel-type ulysses --parallel-text-encoder --quantize-type float8_wo --attn _flash_3 --cache --compile --parallel-vae --ulysses-anything
```

The service will exhibit the following bug after being accessed and hanging for an extended period. 

```shell
INFO:     127.0.0.1:56624 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:56632 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:56646 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:56650 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:56666 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:56678 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33194 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33204 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33210 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33212 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33220 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33224 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33240 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33250 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33256 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:33264 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49490 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49496 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49506 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49508 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49516 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49524 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49536 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     172.16.2.65:26800 - "GET /health HTTP/1.1" 200 OK
INFO:     127.0.0.1:49538 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49542 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:49544 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39404 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39410 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39418 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39422 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39432 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
INFO:     127.0.0.1:39444 - "GET /get_model_info HTTP/1.1" 200 OK
[rank1]:[E125 18:38:34.691141367 ProcessGroupNCCL.cpp:744] [Rank 1] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[rank1]:[E125 18:38:34.691172079 ProcessGroupNCCL.cpp:758] [Rank 1] To avoid data inconsistency, we are taking the entire process down.
[rank1]:[E125 18:38:34.692682900 ProcessGroupNCCL.cpp:2057] [PG ID 2 PG GUID 5(mesh_ulysses) Rank 1] Process group watchdog thread terminated with exception: [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800091 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f713077cb80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7f70d244d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7f70d24521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7f70d245340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7f71292eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7f7131594ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7f7131626850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

terminate called after throwing an instance of 'c10::DistBackendError'
  what():  [PG ID 2 PG GUID 5(mesh_ulysses) Rank 1] Process group watchdog thread terminated with exception: [Rank 1] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800091 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f713077cb80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7f70d244d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7f70d24521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7f70d245340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7f71292eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7f7131594ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7f7131626850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

Exception raised from run at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2063 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f713077cb80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0xe34731 (0x7f70d2429731 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0x9504a1 (0x7f70d1f454a1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: <unknown function> + 0xd828c (0x7f71292eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #4: <unknown function> + 0x94ac3 (0x7f7131594ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #5: <unknown function> + 0x126850 (0x7f7131626850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

[rank3]:[E125 18:38:34.694069081 ProcessGroupNCCL.cpp:744] [Rank 3] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[rank3]:[E125 18:38:34.694094880 ProcessGroupNCCL.cpp:758] [Rank 3] To avoid data inconsistency, we are taking the entire process down.
[rank3]:[E125 18:38:34.695716127 ProcessGroupNCCL.cpp:2057] [PG ID 2 PG GUID 5(mesh_ulysses) Rank 3] Process group watchdog thread terminated with exception: [Rank 3] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800079 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fd428171b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7fd42904d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7fd4290521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7fd42905340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7fd47feeb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7fd487fe6ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7fd488078850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

terminate called after throwing an instance of 'c10::DistBackendError'

 32%|███▏      | 63/200 [37:50<1:22:18, 36.05s/it]
  what():  [PG ID 2 PG GUID 5(mesh_ulysses) Rank 3] Process group watchdog thread terminated with exception: [Rank 3] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800079 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fd428171b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7fd42904d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7fd4290521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7fd42905340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7fd47feeb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7fd487fe6ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7fd488078850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

Exception raised from run at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2063 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fd428171b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0xe34731 (0x7fd429029731 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0x9504a1 (0x7fd428b454a1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: <unknown function> + 0xd828c (0x7fd47feeb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #4: <unknown function> + 0x94ac3 (0x7fd487fe6ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #5: <unknown function> + 0x126850 (0x7fd488078850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

[rank2]:[E125 18:38:34.697891902 ProcessGroupNCCL.cpp:744] [Rank 2] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[rank2]:[E125 18:38:34.697911536 ProcessGroupNCCL.cpp:758] [Rank 2] To avoid data inconsistency, we are taking the entire process down.
[rank2]:[E125 18:38:34.698812301 ProcessGroupNCCL.cpp:2057] [PG ID 2 PG GUID 5(mesh_ulysses) Rank 2] Process group watchdog thread terminated with exception: [Rank 2] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800018 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fc63b571b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7fc63c44d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7fc63c4521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7fc63c45340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7fc6932eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7fc69b49aac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7fc69b52c850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

terminate called after throwing an instance of 'c10::DistBackendError'
[rank0]:[E125 18:38:34.698844066 ProcessGroupNCCL.cpp:744] [Rank 0] Some NCCL operations have failed or timed out. Due to the asynchronous nature of CUDA kernels, subsequent GPU operations might run on corrupted/incomplete data.
[rank0]:[E125 18:38:34.698857551 ProcessGroupNCCL.cpp:758] [Rank 0] To avoid data inconsistency, we are taking the entire process down.
  what():  [PG ID 2 PG GUID 5(mesh_ulysses) Rank 2] Process group watchdog thread terminated with exception: [Rank 2] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800018 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fc63b571b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7fc63c44d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7fc63c4521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7fc63c45340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7fc6932eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7fc69b49aac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7fc69b52c850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

Exception raised from run at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2063 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7fc63b571b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0xe34731 (0x7fc63c429731 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0x9504a1 (0x7fc63bf454a1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: <unknown function> + 0xd828c (0x7fc6932eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #4: <unknown function> + 0x94ac3 (0x7fc69b49aac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #5: <unknown function> + 0x126850 (0x7fc69b52c850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

[rank0]:[E125 18:38:34.699760111 ProcessGroupNCCL.cpp:2057] [PG ID 2 PG GUID 5(mesh_ulysses) Rank 0] Process group watchdog thread terminated with exception: [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800077 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f88eb771b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7f88ec64d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7f88ec6521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7f88ec65340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7f89434eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7f894b5d8ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7f894b66a850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

terminate called after throwing an instance of 'c10::DistBackendError'

 32%|███▏      | 63/200 [37:50<1:22:17, 36.04s/it]
  what():  [PG ID 2 PG GUID 5(mesh_ulysses) Rank 0] Process group watchdog thread terminated with exception: [Rank 0] Watchdog caught collective operation timeout: WorkNCCL(SeqNum=472025, OpType=ALLTOALL_BASE, NumelIn=407003136, NumelOut=407003136, Timeout(ms)=1800000) ran for 1800077 milliseconds before timing out.
Exception raised from checkTimeout at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:686 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f88eb771b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: c10d::ProcessGroupNCCL::WorkNCCL::checkTimeout(std::optional<std::chrono::duration<long, std::ratio<1l, 1000l> > >) + 0x247 (0x7f88ec64d5b7 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: c10d::ProcessGroupNCCL::Watchdog::runLoop() + 0x1691 (0x7f88ec6521c1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: c10d::ProcessGroupNCCL::Watchdog::run() + 0xdf (0x7f88ec65340f in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #4: <unknown function> + 0xd828c (0x7f89434eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #5: <unknown function> + 0x94ac3 (0x7f894b5d8ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #6: <unknown function> + 0x126850 (0x7f894b66a850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

Exception raised from run at /pytorch/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2063 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) + 0x80 (0x7f88eb771b80 in /opt/conda/lib/python3.11/site-packages/torch/lib/libc10.so)
frame #1: <unknown function> + 0xe34731 (0x7f88ec629731 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #2: <unknown function> + 0x9504a1 (0x7f88ec1454a1 in /opt/conda/lib/python3.11/site-packages/torch/lib/libtorch_cuda.so)
frame #3: <unknown function> + 0xd828c (0x7f89434eb28c in /opt/conda/bin/../lib/libstdc++.so.6)
frame #4: <unknown function> + 0x94ac3 (0x7f894b5d8ac3 in /usr/lib/x86_64-linux-gnu/libc.so.6)
frame #5: <unknown function> + 0x126850 (0x7f894b66a850 in /usr/lib/x86_64-linux-gnu/libc.so.6)

W0125 18:38:36.275000 7 site-packages/torch/distributed/elastic/multiprocessing/api.py:908] Sending process 137 closing signal SIGTERM
W0125 18:38:36.276000 7 site-packages/torch/distributed/elastic/multiprocessing/api.py:908] Sending process 138 closing signal SIGTERM
W0125 18:38:36.277000 7 site-packages/torch/distributed/elastic/multiprocessing/api.py:908] Sending process 139 closing signal SIGTERM
E0125 18:38:37.043000 7 site-packages/torch/distributed/elastic/multiprocessing/api.py:882] failed (exitcode: -6) local_rank: 3 (pid: 140) of binary: /opt/conda/bin/python3
Traceback (most recent call last):
  File "/opt/conda/bin/torchrun", line 33, in <module>
    sys.exit(load_entry_point('torch==2.9.1+cu128', 'console_scripts', 'torchrun')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 357, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/run.py", line 936, in main
    run(args)
  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/run.py", line 927, in run
    elastic_launch(
  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/launcher/api.py", line 156, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/torch/distributed/launcher/api.py", line 293, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
cache_dit.serve.serve FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2026-01-25_18:38:36
  host      : prod-flux2-2050-def-flux-2-1205-cc9cd9b7-4qnsp
  rank      : 3 (local_rank: 3)
  exitcode  : -6 (pid: 140)
  error_file: <N/A>
  traceback : Signal 6 (SIGABRT) received by PID 140
============================================================

```