### PR TITLE
svdquant: fast svd decompose, ~18x speedup

### DIFF
--- a/docs/user_guide/QUANTIZATION.md
+++ b/docs/user_guide/QUANTIZATION.md
@@ -349,9 +349,33 @@ quant_config = QuantizeConfig(
   quant_type="svdq_int4_r32", # _r{rank}, e.g., r16, r32, r64, r128, etc.
   calibrate_fn=calibrate_fn,
   serialize_to="./FLUX.2-klein-4B-svdq/",
+  svdq_kwargs={"calibrate_precision": "low"},  # default, optional: low | medium | high
 )
 pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
 ```
+
+<span style="color:green;">Step 3</span>: Build the <span style="color:#c77dff;">QuantizeConfig</span> for SVDQuant, and call <span style="color:#c77dff;">cache_dit.quantize(...)</span> to apply SVDQuant W4A4 quantization to the model. We have to wait some time for the quantization process to finish, as SVDQuant will perform SVD decomposition for each linear layer and compute the quantization parameters based on the collected quantization statistics. The quantized model will be saved to disk in the specified directory.
+
+```python
+# 3. Build the QuantizeConfig for SVDQuant, and call `cache_dit.quantize(...)`.
+quant_config = QuantizeConfig(
+  quant_type="svdq_int4_r32", # _r{rank}, e.g., r16, r32, r64, r128, etc.
+  calibrate_fn=calibrate_fn,
+  serialize_to="./FLUX.2-klein-4B-svdq/",
+  svdq_kwargs={"calibrate_precision": "low"},  # default, optional: low | medium | high
+)
+pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
+```
+
+<span style="color:green;">calibrate_precision</span> now defaults to <span style="color:green;">low</span>, which uses randomized **torch.svd_lowrank** and keeps the calibration math in float32. **medium** and **high** remain available as opt-in debugging or accuracy-investigation modes. On a real FLUX.2-klein-4B PTQ run (**rank=32**, 8 calibration prompts, **1024x1024**), the quantized-model behavior was almost the same across all three modes; the practical difference was mostly PTQ cost. The **speedup** column below refers to quantization-time speedup relative to **high**. 
+
+| calibrate_precision | low-rank route | speedup | PSNR |
+| :---: | :---: | :---: | :---: |
+| low | <span style="color:green;">torch.svd_lowrank</span> with float32 | <span style="color:green;">18.02x</span> | ~same |
+| medium | full <span style="color:green;">torch.linalg.svd</span> with float32 | 3.26x | ~same |
+| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 1.00x | ~same |
+
+In practice the PSNR values are almost the same, so <span style="color:green;">low</span> is the recommended production default. It keeps the best PTQ throughput while preserving the same loaded-model behavior seen from medium and high.
 
 <span style="color:green;">Step 4</span>: The **FLUX.2-klein-4B-svdq** directory now contains: <span style="color:green;">svdq_int4_r32.safetensors</span> and <span style="color:green;">quant_config.json</span>. The quantized model can be loaded with <span style="color:#c77dff;">cache_dit.load(...)</span> for inference or further fine-tuning. For example:
 

--- a/docs/user_guide/QUANTIZATION.md
+++ b/docs/user_guide/QUANTIZATION.md
@@ -369,11 +369,11 @@ pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
 
 <span style="color:green;">calibrate_precision</span> now defaults to <span style="color:green;">low</span>, which uses randomized **torch.svd_lowrank** and keeps the calibration math in float32. **medium** and **high** remain available as opt-in debugging or accuracy-investigation modes. On a real FLUX.2-klein-4B PTQ run (**rank=32**, 8 calibration prompts, **1024x1024**), the quantized-model behavior was almost the same across all three modes; the practical difference was mostly PTQ cost. The **speedup** column below refers to quantization-time speedup relative to **high**. 
 
-| calibrate_precision | low-rank route | speedup | PSNR |
-| :---: | :---: | :---: | :---: |
-| low | <span style="color:green;">torch.svd_lowrank</span> with float32 | <span style="color:green;">18.02x</span> | ~same |
-| medium | full <span style="color:green;">torch.linalg.svd</span> with float32 | 3.26x | ~same |
-| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 1.00x | ~same |
+| calibrate_precision | low-rank route | quantization_s | speedup | PSNR |
+| :---: | :---: | :---: | :---: | :---: |
+| low | <span style="color:green;">torch.svd_lowrank</span> with float32 | 20.2258 | <span style="color:green;">18.02x</span> | ~same, 29.2528 |
+| medium | full <span style="color:green;">torch.linalg.svd</span> with float32 | 111.8944 | 3.26x | ~same, 29.2454 |
+| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 364.4877 | 1.00x | ~same, 29.1880 |
 
 In practice the PSNR values are almost the same, so <span style="color:green;">low</span> is the recommended production default. It keeps the best PTQ throughput while preserving the same loaded-model behavior seen from medium and high.
 

--- a/examples/ptq/flux2_svdq_ptq.py
+++ b/examples/ptq/flux2_svdq_ptq.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import os
 import random
@@ -34,11 +35,11 @@ DEFAULT_INFERENCE_STEPS = 4
 DEFAULT_SEED = 0
 DEFAULT_SVDQ_KWARGS = {
   "streaming": True,
-  "high_precision": False,
-  "fp32_fallback": True,
+  "calibrate_precision": "low",
   "activation_buffer_flush_sample_count": 1,
   "activation_buffer_flush_cpu_bytes": None,
 }
+_CALIBRATE_PRECISION_CHOICES = ("low", "medium", "high")
 
 
 @dataclass(frozen=True)
@@ -127,6 +128,14 @@ def parse_args() -> argparse.Namespace:
     type=int,
     default=128,
     help="Low-rank SVDQ rank. Higher ranks for distillation models.",
+  )
+  parser.add_argument(
+    "--calibrate-precision",
+    choices=_CALIBRATE_PRECISION_CHOICES,
+    default=DEFAULT_SVDQ_KWARGS["calibrate_precision"],
+    help=("Precision policy for PTQ calibration and low-rank decomposition. "
+          "Use low for randomized svd_lowrank, medium for float32 full SVD, "
+          "and high for float64 full SVD."),
   )
   parser.add_argument("--seed",
                       type=int,
@@ -526,6 +535,53 @@ def persist_report(
   return output_path
 
 
+def persist_summary_json(
+  *,
+  output_path: Path,
+  metadata_rows: list[tuple[object, ...]],
+  stage_order: list[StageResult],
+  psnr_rows: list[tuple[object, ...]],
+  artifact_rows: list[tuple[object, ...]],
+) -> Path:
+  """Write a machine-readable summary next to the Markdown report."""
+
+  summary = {
+    "metadata": {
+      str(key): value
+      for key, value in metadata_rows
+    },
+    "stages": {
+      result.stage: {
+        "status": result.status,
+        "warmup_latency_s": result.warmup_latency_s,
+        "image_path": str(result.image_path) if result.image_path is not None else None,
+        "benchmark": None if result.benchmark is None else {
+          "run_count": result.benchmark.run_count,
+          "avg_latency_s": result.benchmark.avg_latency_s,
+          "total_latency_s": result.benchmark.total_latency_s,
+          "peak_memory_gb": result.benchmark.peak_memory_gb,
+          "transformer_weight_cuda_gb": result.benchmark.transformer_weight_cuda_gb,
+        },
+      }
+      for result in stage_order
+    },
+    "psnr_rows": [{
+      "comparison": row[0],
+      "psnr": row[1],
+      "max_abs_diff": row[2],
+      "mean_abs_diff": row[3],
+      "status": row[4],
+    } for row in psnr_rows],
+    "artifacts": {
+      str(name): path
+      for name, path in artifact_rows
+    },
+  }
+  output_path.parent.mkdir(parents=True, exist_ok=True)
+  output_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+  return output_path
+
+
 def load_flux2_pipe(model_source: str, torch_dtype: torch.dtype):
   """Load the FLUX.2-klein pipeline and move it onto CUDA for benchmarking."""
 
@@ -569,6 +625,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
   reports_dir = output_dir / "reports"
   checkpoint_dir = output_dir / "checkpoint"
   report_path = reports_dir / "report.md"
+  summary_path = reports_dir / "summary.json"
 
   prompts_path = Path(args.prompts_path).expanduser().resolve()
   calibration_prompts = load_calibration_prompts(prompts_path, args.calibration_limit)
@@ -584,6 +641,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
   checkpoint_path: Optional[Path] = None
   quant_config_path: Optional[Path] = None
   quantization_time_s: Optional[float] = None
+  quantization_peak_memory_gb: Optional[float] = None
 
   pipe = None
   loaded_pipe = None
@@ -612,12 +670,21 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
         seed=args.seed,
       ),
       serialize_to=str(checkpoint_dir),
-      svdq_kwargs=dict(DEFAULT_SVDQ_KWARGS),
+      svdq_kwargs={
+        **DEFAULT_SVDQ_KWARGS,
+        "calibrate_precision": args.calibrate_precision,
+      },
     )
 
+    reset_cuda_peak_memory()
     quantize_start = time.perf_counter()
     pipe.transformer = cache_dit.quantize(pipe.transformer, quantize_config)
     quantization_time_s = time.perf_counter() - quantize_start
+    if torch.cuda.is_available():
+      torch.cuda.synchronize()
+      quantization_peak_memory_gb = torch.cuda.max_memory_allocated() / (1024 ** 3)
+    else:
+      quantization_peak_memory_gb = 0.0
     checkpoint_path = Path(quantize_config.serialize_to).resolve()
     quant_config_path = checkpoint_path.parent / "quant_config.json"
     pipe.to("cuda")
@@ -751,6 +818,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
     ("model_source", args.model_source),
     ("output_dir", str(output_dir)),
     ("quant_type", quant_type),
+    ("calibrate_precision", args.calibrate_precision),
     ("torch_dtype", str(torch_dtype).replace("torch.", "")),
     ("prompts_path", str(prompts_path)),
     ("calibration_prompt_count", len(calibration_prompts)),
@@ -765,6 +833,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
     ("seed", args.seed),
     ("seed_policy", "fixed seed shared by calibration and validation/testing"),
     ("quantization_time_s", format_float(quantization_time_s)),
+    ("quantization_peak_memory_gb", format_float(quantization_peak_memory_gb)),
     ("checkpoint_size_gb", format_float(checkpoint_size_gb)),
   ]
 
@@ -786,6 +855,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
     ),
     ("comparison_grid", relative_path(comparison_grid_path, output_dir)),
     ("report", relative_path(report_path, output_dir)),
+    ("summary_json", relative_path(summary_path, output_dir)),
   ]
 
   persist_report(
@@ -795,11 +865,19 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
     psnr_rows=psnr_rows,
     artifact_rows=artifact_rows,
   )
+  persist_summary_json(
+    output_path=summary_path,
+    metadata_rows=metadata_rows,
+    stage_order=stage_order,
+    psnr_rows=psnr_rows,
+    artifact_rows=artifact_rows,
+  )
 
   print(f"Calibration prompts: {len(calibration_prompts)}")
   print(f"Validation prompt: {validation_prompt}")
   print(f"Quantized checkpoint: {checkpoint_path}")
   print(f"Report: {report_path}")
+  print(f"Summary JSON: {summary_path}")
   if comparison_grid_path is not None:
     print(f"Comparison grid: {comparison_grid_path}")
 
@@ -808,6 +886,7 @@ def run_example(args: argparse.Namespace) -> dict[str, Path | str | None]:
     "checkpoint_path": checkpoint_path,
     "quant_config_path": quant_config_path,
     "report_path": report_path,
+    "summary_path": summary_path,
     "comparison_grid_path": comparison_grid_path,
   }
 

--- a/src/cache_dit/quantization/config.py
+++ b/src/cache_dit/quantization/config.py
@@ -8,6 +8,7 @@ from ..logger import init_logger
 logger = init_logger(__name__)
 
 _SVDQ_QUANT_TYPE_PATTERN = re.compile(r"^(svdq_int4)_r(\d+)$")
+_SVDQ_CALIBRATE_PRECISIONS = ("low", "medium", "high")
 _SVDQ_KWARGS_DEFAULTS: dict[str, Any] = {
   # If streaming is set to True, Cache-DiT will quantize the model in a streaming manner,
   # which means it will quantize the model using the calibration samples one by one, and
@@ -16,25 +17,11 @@ _SVDQ_KWARGS_DEFAULTS: dict[str, Any] = {
   # will collect the quantization statistics for all calibration samples first, and then
   # compute the quantization parameters and quantize the model. The default value is True.
   "streaming": True,
-  # If high_precision is set to True, Cache-DiT will use higher precision
-  # (e.g., float64) for SVD decomposition and compute the avtivations or
-  # weights scales with float32 precision. This can provide better quantization
-  # precision, but it may cause longer quantization time and higher memory usage
-  # during quantization. If set to False, Cache-DiT will use lower precision
-  # (e.g., float32) for SVD decomposition and compute the activations or weights
-  # scales with bfloat16 precision. This can speed up the quantization process
-  # and reduce memory usage, but it may cause more precision loss. The default
-  # value is False.
-  "high_precision": False,
-  # Only valid when high_precision is set to False. If fp32_fallback is set to True,
-  # Cache-DiT will fallback to using float32 precision if the SVD decomposition with
-  # lower precision (e.g., float16 or bfloat16) is not supported on the current hardware
-  # or for the current input size. This can improve the compatibility of the quantization
-  # process, but it may cause longer quantization time and higher memory usage during
-  # quantization when the fallback happens. If set to False, Cache-DiT will raise an e
-  # rror if low-precision SVD decomposition is not supported, instead of falling back to
-  # float32. The default value is True.
-  "fp32_fallback": True,
+  # Precision plan shared by calibration math and the low-rank decomposition path:
+  # - low: keep calibration math in torch_dtype and use randomized svd_lowrank.
+  # - medium: use float32 calibration math and full torch.linalg.svd.
+  # - high: use float32 calibration math and float64 SVD.
+  "calibrate_precision": "low",
   # Only valid when streaming is set to True. It specifies the number of samples after
   # which the activation buffers will be flushed and the quantization parameters will
   # be updated. This can help to reduce the memory usage during quantization, especially
@@ -67,6 +54,16 @@ def _resolve_svdq_bool_kwarg(key: str, value: Any) -> bool:
   return value
 
 
+def _resolve_svdq_calibrate_precision(key: str, value: Any) -> str:
+  if not isinstance(value, str):
+    raise TypeError(f"svdq_kwargs[{key!r}] must be a str, got {type(value)}.")
+  normalized = value.lower()
+  if normalized not in _SVDQ_CALIBRATE_PRECISIONS:
+    raise ValueError(
+      f"svdq_kwargs[{key!r}] must be one of {_SVDQ_CALIBRATE_PRECISIONS}, got {value!r}.")
+  return normalized
+
+
 def _resolve_svdq_positive_int_or_none(key: str, value: Any) -> int | None:
   if value is None:
     return None
@@ -91,8 +88,7 @@ def _resolve_svdq_kwargs(svdq_kwargs: Optional[Dict[str, Any]]) -> Dict[str, Any
   resolved = dict(_SVDQ_KWARGS_DEFAULTS)
   validators = {
     "streaming": _resolve_svdq_bool_kwarg,
-    "high_precision": _resolve_svdq_bool_kwarg,
-    "fp32_fallback": _resolve_svdq_bool_kwarg,
+    "calibrate_precision": _resolve_svdq_calibrate_precision,
     "activation_buffer_flush_sample_count": _resolve_svdq_positive_int_or_none,
     "activation_buffer_flush_cpu_bytes": _resolve_svdq_positive_int_or_none,
   }

--- a/src/cache_dit/quantization/svdquant/lowrank.py
+++ b/src/cache_dit/quantization/svdquant/lowrank.py
@@ -7,6 +7,101 @@ import torch.linalg
 
 __all__ = ["decompose_lowrank_residual"]
 
+_SVD_PRECISIONS = ("low", "medium", "high")
+_SVD_LOWRANK_BUFFER = 10
+_SVD_LOWRANK_NITER = 4
+_SVD_LOWRANK_SEED = 0
+
+
+def _normalize_svd_precision(svd_precision: str) -> str:
+  if not isinstance(svd_precision, str):
+    raise TypeError(f"svd_precision must be a str, got {type(svd_precision)}.")
+  normalized = svd_precision.lower()
+  if normalized not in _SVD_PRECISIONS:
+    raise ValueError(f"svd_precision must be one of {_SVD_PRECISIONS}, got {svd_precision!r}.")
+  return normalized
+
+
+def _assert_finite_factor(name: str, tensor: torch.Tensor) -> None:
+  if torch.isnan(tensor).any():
+    raise ValueError(f"NaN in {name} while computing the low-rank factors.")
+  if torch.isinf(tensor).any():
+    raise ValueError(f"Inf in {name} while computing the low-rank factors.")
+
+
+def _svd_lowrank_rng_devices(weight: torch.Tensor) -> list[int]:
+  if weight.device.type != "cuda":
+    return []
+  device_index = weight.device.index
+  if device_index is None:
+    device_index = torch.cuda.current_device()
+  return [device_index]
+
+
+def _run_seeded_svd_lowrank(
+  weight: torch.Tensor,
+  *,
+  svd_dtype: torch.dtype,
+  q: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  # Low precision defaults to a randomized algorithm. Keep it deterministic for
+  # reproducible PTQ runs while restoring the caller's RNG state afterwards.
+  with torch.random.fork_rng(devices=_svd_lowrank_rng_devices(weight)):
+    torch.manual_seed(_SVD_LOWRANK_SEED)
+    return torch.svd_lowrank(weight.to(dtype=svd_dtype), q=q, niter=_SVD_LOWRANK_NITER)
+
+
+def _run_randomized_lowrank_svd(
+  weight: torch.Tensor,
+  rank: int,
+  *,
+  svd_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.dtype]:
+  max_rank = min(weight.shape)
+  q = min(max_rank, rank + _SVD_LOWRANK_BUFFER)
+
+  try:
+    u, s, v = _run_seeded_svd_lowrank(weight, svd_dtype=svd_dtype, q=q)
+    factor_dtype = svd_dtype
+  except (NotImplementedError, RuntimeError):
+    if svd_dtype not in (torch.float16, torch.bfloat16):
+      raise
+    u, s, v = _run_seeded_svd_lowrank(weight, svd_dtype=torch.float32, q=q)
+    factor_dtype = torch.float32
+
+  up = u[:, :rank] * s[:rank]
+  down = v[:, :rank].transpose(0, 1)
+  _assert_finite_factor("U * S", up)
+  _assert_finite_factor("V^T", down)
+  return up, down, factor_dtype
+
+
+def _run_full_svd(
+  weight: torch.Tensor,
+  rank: int,
+  *,
+  svd_dtype: torch.dtype,
+  driver: str | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.dtype]:
+  svd_kwargs = {"full_matrices": False}
+  if driver is not None:
+    svd_kwargs["driver"] = driver
+
+  try:
+    u, s, vh = torch.linalg.svd(weight.to(dtype=svd_dtype), **svd_kwargs)
+    factor_dtype = svd_dtype
+  except (NotImplementedError, RuntimeError):
+    if svd_dtype not in (torch.float16, torch.bfloat16):
+      raise
+    u, s, vh = torch.linalg.svd(weight.to(dtype=torch.float32), full_matrices=False)
+    factor_dtype = torch.float32
+
+  up = u[:, :rank] * s[:rank]
+  down = vh[:rank]
+  _assert_finite_factor("U * S", up)
+  _assert_finite_factor("V^T", down)
+  return up, down, factor_dtype
+
 
 @torch.inference_mode()
 def decompose_lowrank_residual(
@@ -14,8 +109,7 @@ def decompose_lowrank_residual(
   rank: int,
   *,
   output_dtype: torch.dtype | None = None,
-  high_precision: bool = False,
-  fp32_fallback: bool = False,
+  svd_precision: str = "low",
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
   """Factor a smoothed weight matrix into low-rank correction and residual.
 
@@ -23,10 +117,9 @@ def decompose_lowrank_residual(
   :param rank: Target rank for the low-rank approximation.
   :param output_dtype: Output dtype for the returned tensors. Defaults to the
     input `weight.dtype`.
-  :param high_precision: Whether to run the SVD in float64 for improved
-    numerical stability.
-  :param fp32_fallback: Whether to fall back to float32 SVD when the backend
-    does not support low-precision decomposition.
+  :param svd_precision: Precision mode for the low-rank decomposition.
+    `"low"` uses randomized `torch.svd_lowrank`, `"medium"` uses the default
+    full SVD route, and `"high"` uses float64 SVD with CUDA `gesvd`.
 
   :returns: A tuple `(down, up, residual)` where `up @ down` is the rank-`rank`
   approximation of `weight`, `down` has shape `[rank, in_features]`, `up` has
@@ -44,32 +137,39 @@ def decompose_lowrank_residual(
   if rank > max_rank:
     raise ValueError(f"rank {rank} exceeds the maximum supported rank {max_rank}.")
 
+  svd_precision = _normalize_svd_precision(svd_precision)
   output_dtype = output_dtype or weight.dtype
   if rank == 0:
     down = torch.empty((0, in_features), dtype=output_dtype, device=weight.device)
     up = torch.empty((out_features, 0), dtype=output_dtype, device=weight.device)
     return down, up, weight.to(dtype=output_dtype)
 
-  if high_precision:
-    svd_dtype = torch.float64
-  elif fp32_fallback:
-    svd_dtype = torch.float32
+  if svd_precision == "low":
+    up, down, factor_dtype = _run_randomized_lowrank_svd(
+      weight,
+      rank,
+      svd_dtype=weight.dtype,
+    )
+  elif svd_precision == "medium":
+    up, down, factor_dtype = _run_full_svd(
+      weight,
+      rank,
+      svd_dtype=weight.dtype,
+    )
   else:
-    svd_dtype = weight.dtype
+    up, down, factor_dtype = _run_full_svd(
+      weight,
+      rank,
+      svd_dtype=torch.float64,
+      driver="gesvd" if weight.device.type == "cuda" else None,
+    )
 
-  try:
-    u, s, vh = torch.linalg.svd(weight.to(dtype=svd_dtype), full_matrices=False)
-  except NotImplementedError as exc:
-    if (not high_precision and not fp32_fallback and svd_dtype in (torch.float16, torch.bfloat16)):
-      raise RuntimeError("Low-precision SVD is not supported on this backend. Re-run with "
-                         "fp32_fallback=True or high_precision=True.") from exc
-    raise
-  up = (u[:, :rank] * s[:rank]).to(dtype=output_dtype)
-  down = vh[:rank].to(dtype=output_dtype)
+  up = up.to(dtype=output_dtype)
+  down = down.to(dtype=output_dtype)
   if (torch.isnan(up).any() or torch.isnan(down).any() or torch.isinf(up).any()
       or torch.isinf(down).any()):
     raise ValueError("Encountered NaN/Inf while computing the low-rank factors.")
 
-  reconstructed = up.to(dtype=svd_dtype) @ down.to(dtype=svd_dtype)
-  residual = (weight.to(dtype=svd_dtype) - reconstructed).to(dtype=output_dtype)
+  reconstructed = up.to(dtype=factor_dtype) @ down.to(dtype=factor_dtype)
+  residual = (weight.to(dtype=factor_dtype) - reconstructed).to(dtype=output_dtype)
   return down, up, residual

--- a/src/cache_dit/quantization/svdquant/ptq.py
+++ b/src/cache_dit/quantization/svdquant/ptq.py
@@ -24,9 +24,9 @@ from .quantizer import validate_svdq_linear_geometry
 logger = init_logger(__name__)
 
 _SVDQ_METADATA_KEY = "cache_dit_svdq_ptq"
-_SVDQ_FORMAT_VERSION = 1
+_SVDQ_FORMAT_VERSION = 2
 _SVDQ_QUANT_CONFIG_FORMAT = "cache_dit_svdq_quant_config"
-_SVDQ_QUANT_CONFIG_VERSION = 1
+_SVDQ_QUANT_CONFIG_VERSION = 2
 _SVDQ_QUANT_CONFIG_FILENAME = "quant_config.json"
 _ROOT_LAYER_NAME = "__root__"
 
@@ -363,7 +363,7 @@ class SVDQPTQCalibrator:
   def register(self) -> None:
     """Register calibration hooks on all candidate float linear layers."""
 
-    high_precision = self.context.svdq_kwargs["high_precision"]
+    calibrate_precision = self.context.svdq_kwargs["calibrate_precision"]
     flush_sample_count = self.context.svdq_kwargs["activation_buffer_flush_sample_count"]
     flush_cpu_bytes = self.context.svdq_kwargs["activation_buffer_flush_cpu_bytes"]
 
@@ -373,7 +373,7 @@ class SVDQPTQCalibrator:
         raise TypeError(
           f"Expected nn.Linear during calibration registration, got {type(submodule)}.")
       torch_dtype = _normalize_dtype(None, submodule.weight.device)
-      math_dtype = _resolve_math_dtype(torch_dtype, high_precision)
+      math_dtype = _resolve_math_dtype(torch_dtype, calibrate_precision)
       self._accumulators[layer_name] = _ActivationSpanAccumulator(
         device=submodule.weight.device,
         torch_dtype=torch_dtype,
@@ -737,8 +737,7 @@ def quantize_svdq_ptq(module: nn.Module, quantize_config: QuantizeConfig) -> nn.
       precision=context.precision,
       torch_dtype=float_module.weight.dtype,
       device=quantize_device,
-      high_precision=context.svdq_kwargs["high_precision"],
-      fp32_fallback=context.svdq_kwargs["fp32_fallback"],
+      calibrate_precision=context.svdq_kwargs["calibrate_precision"],
     )
 
     if layer_name == "":

--- a/src/cache_dit/quantization/svdquant/quantizer.py
+++ b/src/cache_dit/quantization/svdquant/quantizer.py
@@ -21,6 +21,8 @@ __all__ = [
   "validate_svdq_linear_geometry",
 ]
 
+_CALIBRATE_PRECISIONS = ("low", "medium", "high")
+
 
 def validate_svdq_linear_geometry(
   in_features: int,
@@ -121,8 +123,19 @@ def _repair_invalid_scale(scale: torch.Tensor) -> torch.Tensor:
   return scale
 
 
-def _resolve_math_dtype(torch_dtype: torch.dtype, high_precision: bool) -> torch.dtype:
-  return torch.float32 if high_precision else torch_dtype
+def _normalize_calibrate_precision(calibrate_precision: str) -> str:
+  if not isinstance(calibrate_precision, str):
+    raise TypeError(f"calibrate_precision must be a str, got {type(calibrate_precision)}.")
+  normalized = calibrate_precision.lower()
+  if normalized not in _CALIBRATE_PRECISIONS:
+    raise ValueError(
+      f"calibrate_precision must be one of {_CALIBRATE_PRECISIONS}, got {calibrate_precision!r}.")
+  return normalized
+
+
+def _resolve_math_dtype(torch_dtype: torch.dtype, calibrate_precision: str) -> torch.dtype:
+  calibrate_precision = _normalize_calibrate_precision(calibrate_precision)
+  return torch_dtype if calibrate_precision == "low" else torch.float32
 
 
 @torch.inference_mode()
@@ -313,8 +326,7 @@ def _quantize_linear_svdq_w4a4_from_activation_span(
   torch_dtype: torch.dtype | None = None,
   device: torch.device | str | None = None,
   return_state_dict: bool = False,
-  high_precision: bool = False,
-  fp32_fallback: bool = False,
+  calibrate_precision: str = "low",
 ) -> SVDQW4A4Linear | dict[str, torch.Tensor]:
   """Quantize a linear layer when the activation span has already been computed.
 
@@ -334,9 +346,12 @@ def _quantize_linear_svdq_w4a4_from_activation_span(
   :param device: Device where quantization intermediates and outputs are placed.
   :param return_state_dict: Whether to return the module `state_dict` instead
     of an instantiated `SVDQW4A4Linear`.
-  :param high_precision: Whether to use higher-precision intermediate math.
-  :param fp32_fallback: Whether to retry SVD in float32 if low-precision SVD
-    is unsupported on the current backend.
+  :param calibrate_precision: Shared precision policy for calibration math and
+    low-rank decomposition. For activation and weightsmoothing, `"low"` keeps
+    calibration math in `torch_dtype`, while `"medium"` and `"high"` use float32
+    calibration math. For the SVD low-rank decomposition, `"low"` uses `torch.svd_lowrank`
+    in `torch_dtype`, `"medium"` uses the default full SVD route in float32, and `"high"`
+    uses float64 SVD with CUDA `gesvd` for maximum precision.
   :returns: Either a ready-to-load SVDQ module state dict or an instantiated
     `SVDQW4A4Linear`.
   """
@@ -346,7 +361,8 @@ def _quantize_linear_svdq_w4a4_from_activation_span(
 
   device = torch.device(device or linear.weight.device)
   torch_dtype = _normalize_dtype(torch_dtype, device)
-  math_dtype = _resolve_math_dtype(torch_dtype, high_precision)
+  calibrate_precision = _normalize_calibrate_precision(calibrate_precision)
+  math_dtype = _resolve_math_dtype(torch_dtype, calibrate_precision)
   validate_svdq_linear_geometry(linear.in_features,
                                 linear.out_features,
                                 rank=rank,
@@ -373,8 +389,7 @@ def _quantize_linear_svdq_w4a4_from_activation_span(
     smoothed_weight,
     rank,
     output_dtype=torch_dtype,
-    high_precision=high_precision,
-    fp32_fallback=fp32_fallback,
+    svd_precision=calibrate_precision,
   )
   scales = _compute_group_scales(
     residual,
@@ -434,8 +449,7 @@ def quantize_linear_svdq_w4a4(
   torch_dtype: torch.dtype | None = None,
   device: torch.device | str | None = None,
   return_state_dict: bool = False,
-  high_precision: bool = False,
-  fp32_fallback: bool = False,
+  calibrate_precision: str = "low",
   streaming: bool = True,
   activation_buffer_flush_sample_count: int | None = 1,
   activation_buffer_flush_cpu_bytes: int | None = None,
@@ -456,10 +470,8 @@ def quantize_linear_svdq_w4a4(
     should be materialized.
   :param return_state_dict: When `True`, return the packed module `state_dict`
     instead of instantiating `SVDQW4A4Linear`.
-  :param high_precision: Enable higher-precision intermediate math and float64 SVD
-    during low-rank decomposition.
-  :param fp32_fallback: Allow the low-rank decomposition to retry in float32 when a
-    low-precision SVD kernel is unavailable.
+  :param calibrate_precision: Shared precision policy for calibration math and
+    low-rank decomposition.
   :param streaming: Whether to accumulate activation spans incrementally instead of
     materializing all standardized activations at once.
   :param activation_buffer_flush_sample_count: Number of buffered span samples to keep
@@ -476,7 +488,8 @@ def quantize_linear_svdq_w4a4(
 
   device = torch.device(device or linear.weight.device)
   torch_dtype = _normalize_dtype(torch_dtype, device)
-  math_dtype = _resolve_math_dtype(torch_dtype, high_precision)
+  calibrate_precision = _normalize_calibrate_precision(calibrate_precision)
+  math_dtype = _resolve_math_dtype(torch_dtype, calibrate_precision)
   validate_svdq_linear_geometry(linear.in_features,
                                 linear.out_features,
                                 rank=rank,
@@ -518,6 +531,5 @@ def quantize_linear_svdq_w4a4(
     torch_dtype=torch_dtype,
     device=device,
     return_state_dict=return_state_dict,
-    high_precision=high_precision,
-    fp32_fallback=fp32_fallback,
+    calibrate_precision=calibrate_precision,
   )

--- a/tests/kernels/test_svdquant_runtime.py
+++ b/tests/kernels/test_svdquant_runtime.py
@@ -469,7 +469,7 @@ def test_svdquant_operator_rank_accuracy_improves_with_rank() -> None:
         device=device,
         torch_dtype=dtype,
         return_state_dict=True,
-        calibrate_precision="medium",
+        calibrate_precision="low",
         streaming=True,
       )
       operator_output = run_svdq_operator_from_state_dict(
@@ -532,7 +532,7 @@ def test_svdquant_operator_v2_rank_accuracy_improves_with_rank() -> None:
         device=device,
         torch_dtype=dtype,
         return_state_dict=True,
-        calibrate_precision="medium",
+        calibrate_precision="low",
         streaming=True,
       )
       operator_output = run_svdq_operator_from_state_dict(

--- a/tests/kernels/test_svdquant_runtime.py
+++ b/tests/kernels/test_svdquant_runtime.py
@@ -469,8 +469,7 @@ def test_svdquant_operator_rank_accuracy_improves_with_rank() -> None:
         device=device,
         torch_dtype=dtype,
         return_state_dict=True,
-        high_precision=False,
-        fp32_fallback=True,
+        calibrate_precision="medium",
         streaming=True,
       )
       operator_output = run_svdq_operator_from_state_dict(
@@ -533,8 +532,7 @@ def test_svdquant_operator_v2_rank_accuracy_improves_with_rank() -> None:
         device=device,
         torch_dtype=dtype,
         return_state_dict=True,
-        high_precision=False,
-        fp32_fallback=True,
+        calibrate_precision="medium",
         streaming=True,
       )
       operator_output = run_svdq_operator_from_state_dict(

--- a/tests/quantization/_svdq_test_utils.py
+++ b/tests/quantization/_svdq_test_utils.py
@@ -364,8 +364,7 @@ def quantize_toy_model(
   rank: int,
   device: str | torch.device,
   dtype: torch.dtype,
-  high_precision: bool = False,
-  fp32_fallback: bool = False,
+  calibrate_precision: str = "low",
   streaming: bool = True,
 ) -> ToyModel:
   activations_by_module = collect_module_inputs(model, calibration_samples)
@@ -378,8 +377,7 @@ def quantize_toy_model(
       rank=rank,
       device=device,
       torch_dtype=dtype,
-      high_precision=high_precision,
-      fp32_fallback=fp32_fallback,
+      calibrate_precision=calibrate_precision,
       streaming=streaming,
     )
     parent, child_name = _module_parent(quantized_model, module_name)

--- a/tests/quantization/test_svdquant_compile.py
+++ b/tests/quantization/test_svdquant_compile.py
@@ -38,7 +38,7 @@ def test_svdquant_w4a4_module_torch_compile_fullgraph_smoke() -> None:
     rank=16,
     device=device,
     torch_dtype=dtype,
-    calibrate_precision="medium",
+    calibrate_precision="low",
     streaming=True,
   ).eval()
 
@@ -75,7 +75,7 @@ def test_svdquant_w4a4_module_torch_compile_fullgraph_v2_smoke() -> None:
     rank=16,
     device=device,
     torch_dtype=dtype,
-    calibrate_precision="medium",
+    calibrate_precision="low",
     streaming=True,
   ).eval()
   quantized.runtime_kernel = "v2"

--- a/tests/quantization/test_svdquant_compile.py
+++ b/tests/quantization/test_svdquant_compile.py
@@ -38,8 +38,7 @@ def test_svdquant_w4a4_module_torch_compile_fullgraph_smoke() -> None:
     rank=16,
     device=device,
     torch_dtype=dtype,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=True,
   ).eval()
 
@@ -76,8 +75,7 @@ def test_svdquant_w4a4_module_torch_compile_fullgraph_v2_smoke() -> None:
     rank=16,
     device=device,
     torch_dtype=dtype,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=True,
   ).eval()
   quantized.runtime_kernel = "v2"

--- a/tests/quantization/test_svdquant_ptq.py
+++ b/tests/quantization/test_svdquant_ptq.py
@@ -37,8 +37,7 @@ _SVDQ_METADATA_KEY_NAME = "cache_dit_svdq_ptq"
 _SVDQ_QUANT_CONFIG_FILENAME = "quant_config.json"
 _DEFAULT_SVDQ_KWARGS = {
   "streaming": True,
-  "high_precision": False,
-  "fp32_fallback": True,
+  "calibrate_precision": "low",
   "activation_buffer_flush_sample_count": 1,
   "activation_buffer_flush_cpu_bytes": None,
 }
@@ -818,8 +817,7 @@ def _run_flux2_svdq_case(
         exclude_layers=exclude_layers,
         svdq_kwargs={
           "streaming": True,
-          "high_precision": False,
-          "fp32_fallback": True,
+          "calibrate_precision": "medium",
         },
       )
 
@@ -1404,6 +1402,30 @@ def test_svdq_ptq_config_validation_rejects_invalid_combinations(tmp_path: Path)
       svdq_kwargs={"activation_buffer_flush_cpu_bytes": True},
     )
 
+  with pytest.raises(TypeError, match="must be a str"):
+    QuantizeConfig(
+      quant_type="svdq_int4_r32",
+      calibrate_fn=lambda **_: None,
+      serialize_to=str(tmp_path / "bad_calibrate_precision_type"),
+      svdq_kwargs={"calibrate_precision": 1},
+    )
+
+  with pytest.raises(ValueError, match="must be one of"):
+    QuantizeConfig(
+      quant_type="svdq_int4_r32",
+      calibrate_fn=lambda **_: None,
+      serialize_to=str(tmp_path / "bad_calibrate_precision_value"),
+      svdq_kwargs={"calibrate_precision": "ultra"},
+    )
+
+  with pytest.raises(ValueError, match="Unsupported SVDQ PTQ kwargs"):
+    QuantizeConfig(
+      quant_type="svdq_int4_r32",
+      calibrate_fn=lambda **_: None,
+      serialize_to=str(tmp_path / "legacy_precision_keys"),
+      svdq_kwargs={"high_precision": True},
+    )
+
 
 def test_svdq_ptq_load_rejects_invalid_or_incomplete_metadata(tmp_path: Path) -> None:
   from safetensors.torch import save_file
@@ -1428,13 +1450,28 @@ def test_svdq_ptq_load_rejects_invalid_or_incomplete_metadata(tmp_path: Path) ->
       str(malformed_metadata_path),
     )
 
+  legacy_metadata_path = tmp_path / "legacy_metadata.safetensors"
+  save_file(
+    {"dummy": torch.zeros(1)},
+    str(legacy_metadata_path),
+    metadata={
+      _SVDQ_METADATA_KEY_NAME:
+      '{"format":"cache_dit_svdq_ptq","version":1,"quant_type":"svdq_int4_r32","rank":32,"quantized_layer_names":["block.to_q"],"svdq_kwargs":{"streaming":true,"high_precision":false,"fp32_fallback":true}}'
+    },
+  )
+  with pytest.raises(ValueError, match="Unsupported SVDQ PTQ checkpoint version 1"):
+    cache_dit.load(
+      torch.nn.Linear(128, 128, device="cuda", dtype=runtime_dtype()),
+      str(legacy_metadata_path),
+    )
+
   incomplete_metadata_path = tmp_path / "incomplete_metadata.safetensors"
   save_file(
     {"dummy": torch.zeros(1)},
     str(incomplete_metadata_path),
     metadata={
       _SVDQ_METADATA_KEY_NAME:
-      '{"format":"cache_dit_svdq_ptq","version":1,"quant_type":"svdq_int4_r32","rank":32,"quantized_layer_names":["block.to_q"],"svdq_kwargs":{"streaming":true,"high_precision":false,"fp32_fallback":true}}'
+      '{"format":"cache_dit_svdq_ptq","version":2,"quant_type":"svdq_int4_r32","rank":32,"quantized_layer_names":["block.to_q"],"svdq_kwargs":{"streaming":true,"calibrate_precision":"medium"}}'
     },
   )
   with pytest.raises(ValueError, match="No serialized tensors found"):

--- a/tests/quantization/test_svdquant_quantizer.py
+++ b/tests/quantization/test_svdquant_quantizer.py
@@ -224,7 +224,7 @@ def test_svdquant_quantizer_streaming_matches_eager_state_dict() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    calibrate_precision="medium",
+    calibrate_precision=_CALIBRATE_PRECISION,
     streaming=True,
   )
   eager = quantize_linear_svdq_w4a4(
@@ -234,7 +234,7 @@ def test_svdquant_quantizer_streaming_matches_eager_state_dict() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    calibrate_precision="medium",
+    calibrate_precision=_CALIBRATE_PRECISION,
     streaming=False,
   )
 
@@ -275,7 +275,7 @@ def test_svdquant_quantizer_streaming_flush_thresholds_match_eager_state_dict(
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    calibrate_precision="medium",
+    calibrate_precision=_CALIBRATE_PRECISION,
     streaming=True,
     **buffer_kwargs,
   )
@@ -286,7 +286,7 @@ def test_svdquant_quantizer_streaming_flush_thresholds_match_eager_state_dict(
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    calibrate_precision="medium",
+    calibrate_precision=_CALIBRATE_PRECISION,
     streaming=False,
   )
 

--- a/tests/quantization/test_svdquant_quantizer.py
+++ b/tests/quantization/test_svdquant_quantizer.py
@@ -9,6 +9,7 @@ import torch
 from torch import nn
 
 from cache_dit.kernels import svdq_extension_is_available
+from cache_dit.quantization.svdquant.lowrank import decompose_lowrank_residual
 from cache_dit.quantization.svdquant import SVDQW4A4Linear
 from cache_dit.quantization.svdquant import quantize_linear_svdq_w4a4
 from tests.quantization._svdq_test_utils import EVALUATED_RANKS
@@ -25,8 +26,7 @@ from tests.quantization._svdq_test_utils import make_toy_model
 from tests.quantization._svdq_test_utils import quantize_toy_model
 from tests.quantization._svdq_test_utils import runtime_dtype
 
-_USE_HIGH_PRECISION = os.getenv("CACHE_DIT_SVDQ_TEST_HIGH_PRECISION", "0").lower() == "1"
-_USE_FP32_FALLBACK = os.getenv("CACHE_DIT_SVDQ_TEST_FP32_FALLBACK", "1").lower() == "1"
+_CALIBRATE_PRECISION = os.getenv("CACHE_DIT_SVDQ_TEST_CALIBRATE_PRECISION", "low").lower()
 _ENABLE_STREAMING_MEMORY_BENCH = os.getenv("CACHE_DIT_SVDQ_TEST_LARGE_MEMORY", "0").lower() == "1"
 _ENABLE_LARGE_HEAD_NUMBER = os.getenv("CACHE_DIT_SVDQ_TEST_LARGE_HEAD_NUM", "0").lower() == "1"
 _LARGE_MEMORY_TOTAL_GIB = float(os.getenv("CACHE_DIT_SVDQ_TEST_LARGE_MEMORY_GIB", "10"))
@@ -35,11 +35,13 @@ _STREAMING_MEMORY_THRESHOLD_PCT = float(
   os.getenv("CACHE_DIT_SVDQ_TEST_STREAMING_MEMORY_THRESHOLD_PCT", "25"))
 _LARGE_MEMORY_MIN_DEVICE_GIB = float(os.getenv("CACHE_DIT_SVDQ_TEST_LARGE_MEMORY_MIN_GIB", "12"))
 
+if _CALIBRATE_PRECISION not in {"low", "medium", "high"}:
+  raise ValueError("CACHE_DIT_SVDQ_TEST_CALIBRATE_PRECISION must be one of low, medium, high.")
+
 
 def _quantizer_kwargs(**overrides: object) -> dict[str, object]:
   kwargs: dict[str, object] = {
-    "high_precision": _USE_HIGH_PRECISION,
-    "fp32_fallback": _USE_FP32_FALLBACK,
+    "calibrate_precision": _CALIBRATE_PRECISION,
     "streaming": True,
     "activation_buffer_flush_sample_count": 1,
     "activation_buffer_flush_cpu_bytes": None,
@@ -49,22 +51,11 @@ def _quantizer_kwargs(**overrides: object) -> dict[str, object]:
 
 
 def _current_tolerance() -> tuple[float, float]:
-  if _USE_HIGH_PRECISION:
+  if _CALIBRATE_PRECISION == "high":
     return 4e-2, 1e-2
-  if _USE_FP32_FALLBACK:
+  if _CALIBRATE_PRECISION == "medium":
     return 6e-2, 2e-2
   return 1e-1, 1e-1
-
-
-def _supports_low_precision_svd(device: str, dtype: torch.dtype) -> bool:
-  try:
-    matrix = torch.randn(32, 32, device=device, dtype=dtype)
-    torch.linalg.svd(matrix, full_matrices=False)
-    if device == "cuda":
-      torch.cuda.synchronize()
-    return True
-  except (NotImplementedError, RuntimeError):
-    return False
 
 
 def _make_large_cpu_calibration_list(
@@ -133,7 +124,7 @@ def test_svdquant_quantizer_returns_module_state_dict() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    **_quantizer_kwargs(fp32_fallback=True),
+    **_quantizer_kwargs(),
   )
 
   assert set(state_dict) == {
@@ -166,7 +157,7 @@ def test_svdquant_quantizer_repairs_invalid_smooth_scales() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    **_quantizer_kwargs(fp32_fallback=True),
+    **_quantizer_kwargs(),
   )
 
   assert torch.equal(state_dict["smooth_factor"], torch.ones_like(state_dict["smooth_factor"]))
@@ -187,7 +178,7 @@ def test_svdquant_quantizer_rejects_unsupported_geometry() -> None:
       device="cpu",
       torch_dtype=torch.bfloat16,
       return_state_dict=True,
-      **_quantizer_kwargs(fp32_fallback=True),
+      **_quantizer_kwargs(),
     )
 
 
@@ -204,7 +195,7 @@ def test_svdquant_quantizer_state_dict_loads_into_module() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    **_quantizer_kwargs(fp32_fallback=True),
+    **_quantizer_kwargs(),
   )
 
   module = SVDQW4A4Linear.from_linear(
@@ -233,8 +224,7 @@ def test_svdquant_quantizer_streaming_matches_eager_state_dict() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=True,
   )
   eager = quantize_linear_svdq_w4a4(
@@ -244,8 +234,7 @@ def test_svdquant_quantizer_streaming_matches_eager_state_dict() -> None:
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=False,
   )
 
@@ -286,8 +275,7 @@ def test_svdquant_quantizer_streaming_flush_thresholds_match_eager_state_dict(
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=True,
     **buffer_kwargs,
   )
@@ -298,8 +286,7 @@ def test_svdquant_quantizer_streaming_flush_thresholds_match_eager_state_dict(
     device="cpu",
     torch_dtype=torch.bfloat16,
     return_state_dict=True,
-    high_precision=False,
-    fp32_fallback=True,
+    calibrate_precision="medium",
     streaming=False,
   )
 
@@ -308,34 +295,122 @@ def test_svdquant_quantizer_streaming_flush_thresholds_match_eager_state_dict(
     torch.testing.assert_close(buffered[key], eager[key], rtol=0.0, atol=0.0)
 
 
-def test_svdquant_quantizer_low_precision_svd_requires_fallback_when_unsupported() -> None:
-  linear = _make_cpu_linear(128, 128)
-  representative = torch.randn(2, 128, dtype=torch.bfloat16)
+@pytest.mark.parametrize("svd_precision", ["low", "medium", "high"])
+def test_decompose_lowrank_residual_modes_return_finite_tensors(svd_precision: str) -> None:
+  weight = torch.randn(128, 128, dtype=torch.bfloat16)
 
-  if _supports_low_precision_svd("cpu", torch.bfloat16):
-    quantize_linear_svdq_w4a4(
-      linear,
-      representative,
-      rank=16,
-      device="cpu",
-      torch_dtype=torch.bfloat16,
-      return_state_dict=True,
-      high_precision=False,
-      fp32_fallback=False,
-    )
-    return
+  down, up, residual = decompose_lowrank_residual(
+    weight,
+    rank=16,
+    output_dtype=torch.bfloat16,
+    svd_precision=svd_precision,
+  )
 
-  with pytest.raises(RuntimeError, match="Low-precision SVD is not supported"):
-    quantize_linear_svdq_w4a4(
-      linear,
-      representative,
-      rank=16,
-      device="cpu",
-      torch_dtype=torch.bfloat16,
-      return_state_dict=True,
-      high_precision=False,
-      fp32_fallback=False,
-    )
+  assert down.shape == (16, 128)
+  assert up.shape == (128, 16)
+  assert residual.shape == (128, 128)
+  assert torch.isfinite(down).all()
+  assert torch.isfinite(up).all()
+  assert torch.isfinite(residual).all()
+
+
+def test_decompose_lowrank_residual_low_uses_svd_lowrank_and_float32_retry(
+  monkeypatch: pytest.MonkeyPatch, ) -> None:
+  original = torch.svd_lowrank
+  calls: list[tuple[torch.dtype, int, int]] = []
+
+  def wrapped(matrix: torch.Tensor, *args, **kwargs):
+    calls.append((matrix.dtype, kwargs["q"], kwargs["niter"]))
+    if matrix.dtype == torch.bfloat16:
+      raise RuntimeError("simulated low-precision svd_lowrank failure")
+    return original(matrix, *args, **kwargs)
+
+  monkeypatch.setattr(torch, "svd_lowrank", wrapped)
+
+  down, up, residual = decompose_lowrank_residual(
+    torch.randn(64, 64, dtype=torch.bfloat16),
+    rank=16,
+    output_dtype=torch.bfloat16,
+    svd_precision="low",
+  )
+
+  assert calls == [(torch.bfloat16, 26, 4), (torch.float32, 26, 4)]
+  assert torch.isfinite(down).all()
+  assert torch.isfinite(up).all()
+  assert torch.isfinite(residual).all()
+
+
+def test_decompose_lowrank_residual_low_is_deterministic() -> None:
+  weight = torch.randn(64, 64, dtype=torch.bfloat16)
+
+  first = decompose_lowrank_residual(
+    weight,
+    rank=16,
+    output_dtype=torch.bfloat16,
+    svd_precision="low",
+  )
+  second = decompose_lowrank_residual(
+    weight,
+    rank=16,
+    output_dtype=torch.bfloat16,
+    svd_precision="low",
+  )
+
+  for lhs, rhs in zip(first, second):
+    torch.testing.assert_close(lhs, rhs, rtol=0.0, atol=0.0)
+
+
+def test_decompose_lowrank_residual_medium_retries_in_float32(
+  monkeypatch: pytest.MonkeyPatch, ) -> None:
+  original = torch.linalg.svd
+  calls: list[tuple[torch.dtype, str | None]] = []
+
+  def wrapped(matrix: torch.Tensor, *args, **kwargs):
+    calls.append((matrix.dtype, kwargs.get("driver")))
+    if matrix.dtype == torch.bfloat16:
+      raise RuntimeError("simulated low-precision full SVD failure")
+    return original(matrix, *args, **kwargs)
+
+  monkeypatch.setattr(torch.linalg, "svd", wrapped)
+
+  down, up, residual = decompose_lowrank_residual(
+    torch.randn(64, 64, dtype=torch.bfloat16),
+    rank=16,
+    output_dtype=torch.bfloat16,
+    svd_precision="medium",
+  )
+
+  assert calls == [(torch.bfloat16, None), (torch.float32, None)]
+  assert torch.isfinite(down).all()
+  assert torch.isfinite(up).all()
+  assert torch.isfinite(residual).all()
+
+
+def test_decompose_lowrank_residual_high_uses_expected_driver(
+  monkeypatch: pytest.MonkeyPatch, ) -> None:
+  original = torch.linalg.svd
+  calls: list[tuple[torch.dtype, str | None]] = []
+
+  def wrapped(matrix: torch.Tensor, *args, **kwargs):
+    calls.append((matrix.dtype, kwargs.get("driver")))
+    return original(matrix, *args, **kwargs)
+
+  monkeypatch.setattr(torch.linalg, "svd", wrapped)
+
+  device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+  dtype = (torch.bfloat16
+           if device.type == "cuda" and torch.cuda.is_bf16_supported() else torch.float32)
+  weight = torch.randn(64, 64, device=device, dtype=dtype)
+
+  decompose_lowrank_residual(
+    weight,
+    rank=16,
+    output_dtype=dtype,
+    svd_precision="high",
+  )
+
+  expected_driver = "gesvd" if device.type == "cuda" else None
+  assert calls == [(torch.float64, expected_driver)]
 
 
 def test_svdquant_quantizer_runtime_rank32_beats_rank0() -> None:
@@ -481,8 +556,7 @@ def test_svdquant_toymodel_rank_accuracy_roundtrip_report(tmp_path: Path) -> Non
       rank=rank,
       device=device,
       dtype=dtype,
-      high_precision=_USE_HIGH_PRECISION,
-      fp32_fallback=_USE_FP32_FALLBACK,
+      calibrate_precision=_CALIBRATE_PRECISION,
     )
     torch.cuda.synchronize()
     quantize_latency = time.perf_counter() - quantize_start_time
@@ -540,8 +614,8 @@ def test_svdquant_toymodel_rank_accuracy_roundtrip_report(tmp_path: Path) -> Non
   print(
     format_markdown_table(
       "SVDQ ToyModel profiling config\n",
-      ("num_heads", "embed_dim", "batch", "seq_len", "high_precision", "fp32_fallback"),
-      [(H, D, B, S, _USE_HIGH_PRECISION, _USE_FP32_FALLBACK)],
+      ("num_heads", "embed_dim", "batch", "seq_len", "calibrate_precision"),
+      [(H, D, B, S, _CALIBRATE_PRECISION)],
     ))
   print(
     format_markdown_table(


### PR DESCRIPTION
<span style="color:green;">calibrate_precision</span> now defaults to <span style="color:green;">low</span>, which uses randomized **torch.svd_lowrank** and keeps the calibration math in float32. **medium** and **high** remain available as opt-in debugging or accuracy-investigation modes. On a real FLUX.2-klein-4B PTQ run (**rank=32**, 8 calibration prompts, **1024x1024**), the quantized-model behavior was almost the same across all three modes; the practical difference was mostly PTQ cost. The **speedup** column below refers to quantization-time speedup relative to **high**. 

| calibrate_precision | low-rank route | quantization_s | speedup | PSNR |
| :---: | :---: | :---: | :---: | :---: |
| low | <span style="color:green;">torch.svd_lowrank</span> with float32 | 20.2258 | <span style="color:green;">18.02x</span> | ~same, 29.2528 |
| medium | full <span style="color:green;">torch.linalg.svd</span> with float32 | 111.8944 | 3.26x | ~same, 29.2454 |
| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 364.4877 | 1.00x | ~same, 29.1880 |


In practice the PSNR values are almost the same, so <span style="color:green;">low</span> is the recommended production default. It keeps the best PTQ throughput while preserving the same loaded-model behavior seen from medium and high.
