### PR TITLE
[2/N] tune svdq w4a4 gemm for ada

### DIFF
--- a/.copilot/skills/cuda-cpp-kernel/SKILL.md
+++ b/.copilot/skills/cuda-cpp-kernel/SKILL.md
@@ -126,9 +126,10 @@ If the task is a migration into cache-dit, keep the kernel work separate from re
 
 1. Reproduce the issue with the smallest input that still fails.
 2. Confirm the failure mode: wrong value, launch error, illegal memory access, race, hang, or performance regression.
-3. Use compute-sanitizer or cuda-gdb for correctness problems.
-4. Use Nsight Systems first for end-to-end bottlenecks, then Nsight Compute for per-kernel root cause.
-5. After each change, rerun the focused correctness test before doing broader benchmarks.
+3. When the kernel uses shared memory, `cp.async`, or any other asynchronous staging path, treat data-synchronization bugs as a first-line hypothesis. If only some shapes or stage-count cases fail, suspect missing barriers, premature shared-memory slot reuse, or incomplete predicate protection before assuming the math is wrong.
+4. Use compute-sanitizer or cuda-gdb for correctness problems.
+5. Use Nsight Systems first for end-to-end bottlenecks, then Nsight Compute for per-kernel root cause.
+6. After each change, rerun the focused correctness test before doing broader benchmarks.
 
 ## Performance Workflow
 

--- a/.copilot/skills/cuda-cpp-kernel/SKILL.md
+++ b/.copilot/skills/cuda-cpp-kernel/SKILL.md
@@ -100,8 +100,8 @@ Use the bundled architecture guides as the first reference for cross-architectur
 
 1. For `sm89`, focus on memory throughput, L2 hit rate, kernel fusion opportunity, and the lack of TMA or cluster features.
 2. For `sm90`, focus on TMA overlap, warpgroup behavior, shared-memory staging, and whether the timeline shows good load or compute overlap.
-3. For `sm100` and `sm103`, focus on WGMMA or tcgen05 usage, TMEM behavior, TMA v2 overlap, cluster behavior, and whether the kernel actually benefits from Blackwell datacenter features.
-4. For `sm120`, treat it closer to Ada than to datacenter Blackwell for profiling purposes: watch memory throughput, L2 hit rate, shared-memory limits, and the absence of TMA, TMEM, or cluster features.
+3. For `sm100` and `sm103`, focus on `tcgen05` usage, TMEM behavior, TMA v2 overlap, cluster behavior, and whether the kernel actually benefits from Blackwell datacenter features.
+4. For `sm120`, treat it closer to Ada than to datacenter Blackwell for profiling purposes: watch memory throughput, L2 hit rate, shared-memory limits, and the lack of TMEM or cluster features while deciding explicitly whether TMA or `cp.async` is the better staging path.
 
 Recommended order:
 

--- a/.copilot/skills/cuda-cpp-kernel/sm100-optimization-guide.md
+++ b/.copilot/skills/cuda-cpp-kernel/sm100-optimization-guide.md
@@ -32,7 +32,7 @@ Deep dive into B200/GB200-specific optimizations for CUDA kernels.
 2. **5th-Gen Tensor Cores** - FP4/FP6/FP8/FP16/BF16/TF32 support, 2x throughput vs Hopper
 3. **Tensor Memory Accelerator (TMA)** - Enhanced over Hopper with multicast and bulk async operations
 4. **Thread Block Clusters** - Groups of thread blocks that cooperate via distributed shared memory
-5. **WGMMA (Warp Group Matrix Multiply-Accumulate)** - New instruction replacing Hopper's GMMA
+5. **tcgen05 Tensor Core MMA** - Blackwell replaces Hopper's `wgmma.mma_async` path with `tcgen05` tensor-core instructions
 6. **Tensor Memory (TMEM)** - Dedicated memory for tensor core operands, separate from register file
 7. **tcgen05** - New tensor core generation instruction set
 8. **NVFP4** - Native 4-bit floating point in tensor cores
@@ -57,7 +57,7 @@ Deep dive into B200/GB200-specific optimizations for CUDA kernels.
 | Tensor Core gen           | 5th gen              | 4th gen                  |
 | FP4 support               | Yes (NVFP4)          | No                       |
 | FP6 support               | Yes                  | No                       |
-| WGMMA / tcgen05           | Yes                  | No (uses wgmma.mma_async)|
+| tcgen05 tensor-core MMA   | Yes                  | No (uses wgmma.mma_async)|
 | Tensor Memory (TMEM)      | Yes                  | No                       |
 | NVLink                    | 5.0 (1.8 TB/s)      | 4.0 (900 GB/s)           |
 
@@ -300,35 +300,29 @@ val = max(val, max_val);
 // ... repeat for 8, 4, 2, 1
 ```
 
-### WGMMA (Warp Group Matrix Multiply-Accumulate)
+### Warp-Group Tensor Core MMA (`tcgen05`)
 
-Blackwell introduces `tcgen05` instructions that supersede Hopper's GMMA. WGMMA operates on warp groups (4 warps = 128 threads):
+Blackwell does not use Hopper's `wgmma.mma_async` instruction. Instead it introduces the `tcgen05.*` tensor-core instruction family, coupled with TMEM and TMA-based staging for warp-group style GEMM pipelines:
 
 ```cuda
-// WGMMA: Matrix multiply using Tensor Memory (TMEM)
+// Blackwell tcgen05 tensor-core flow:
 // Operand A comes from TMEM (dedicated tensor memory, not registers)
 // Operand B comes from shared memory or TMEM
 // Result accumulates in TMEM
 
 // Key advantage: TMEM is separate from the 64K register file
-// This means WGMMA doesn't consume registers for tensor operands
+// This means tcgen05 MMA doesn't consume registers for tensor operands
 
-// Typical WGMMA shapes (M x N x K):
+// Typical warp-group tensor-core shapes (M x N x K):
 // FP16/BF16: 64x256x16, 64x128x16, 64x64x16
 // FP8:       64x256x32, 64x128x32, 64x64x32
 // FP4:       64x256x64, 64x128x64, 64x64x64
 
-// WGMMA is accessed via CUTLASS or inline PTX:
-asm volatile(
-    "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 "
-    "{%0, %1, %2, %3, %4, %5, %6, %7, "
-    " %8, %9, %10, %11, %12, %13, %14, %15, "
-    " %16, %17, %18, %19, %20, %21, %22, %23, "
-    " %24, %25, %26, %27, %28, %29, %30, %31}, "
-    " %32, %33, p;"
-    : /* outputs (accumulator in TMEM) */
-    : /* inputs (desc_a from TMEM, desc_b from smem) */
-);
+// Practical programming model:
+// 1. Use TMA to stage regular tiles into shared memory
+// 2. Use tcgen05.alloc / tcgen05.ld / tcgen05.cp to manage TMEM state
+// 3. Issue tcgen05.mma / tcgen05.mma.ws through inline PTX or higher-level libraries
+// 4. Commit/wait with tcgen05 fences instead of Hopper wgmma proxy ops
 ```
 
 ### Tensor Memory (TMEM)
@@ -338,9 +332,9 @@ TMEM is a new memory space dedicated to tensor core operands, separate from regi
 ```cuda
 // TMEM key properties:
 // - Not part of the 64K register file per SM
-// - Accessed exclusively by tensor cores via tcgen05/WGMMA
+// - Accessed exclusively by tensor cores via tcgen05 MMA instructions
 // - Reduces register pressure for GEMM/attention kernels
-// - Operands must be staged into TMEM before WGMMA
+// - Operands must be staged into TMEM before tcgen05 MMA
 
 // Practical impact:
 // - On Hopper: tensor operands consumed registers, limiting occupancy
@@ -563,9 +557,9 @@ Key changes when porting kernels from H100 to B200:
 // Hopper: cluster_size = 2
 // Blackwell: cluster_size = 2-4 (better cross-block communication)
 
-// 3. Replace wgmma.mma_async with tcgen05 WGMMA
-// Hopper: wgmma.mma_async (register → smem)
-// Blackwell: tcgen05 WGMMA (TMEM → smem), frees registers
+// 3. Replace Hopper's wgmma.mma_async path with Blackwell tcgen05 MMA
+// Hopper: wgmma.mma_async with register-fragment A operands
+// Blackwell: tcgen05 MMA with TMEM-backed operands, freeing registers
 
 // 4. Use TMA multicast for shared loads across clusters
 // Hopper: each block loads its own copy

--- a/.copilot/skills/cuda-cpp-kernel/sm103-optimization-guide.md
+++ b/.copilot/skills/cuda-cpp-kernel/sm103-optimization-guide.md
@@ -35,7 +35,7 @@ Deep dive into B300/GB300-specific optimizations for CUDA kernels.
 5. **208B Transistors** - Dual-die design, same NVLink-C2C interconnect as B200
 6. **PCIe Gen6** - 2x PCIe Gen5 bandwidth for host-device transfers
 7. **1,400W TDP** - Higher power budget enables sustained boost clocks
-8. **Same SM microarchitecture as sm100** - WGMMA, TMEM, tcgen05, TMA v2 all carry over
+8. **Same SM microarchitecture as sm100** - tcgen05, TMEM, and TMA v2 all carry over
 
 ### Key Differences from Blackwell (sm100)
 
@@ -51,7 +51,7 @@ Deep dive into B300/GB300-specific optimizations for CUDA kernels.
 | Registers/SM              | 65536                   | 65536                    |
 | Memory bandwidth          | 8 TB/s                  | 8 TB/s                   |
 | Tensor cores per SM       | Same (5th gen)          | 5th gen                  |
-| WGMMA / tcgen05 / TMEM    | Yes                     | Yes                      |
+| tcgen05 / TMEM / TMA      | Yes                     | Yes                      |
 | TMA v2 (multicast)        | Yes                     | Yes                      |
 | Thread Block Clusters     | Yes                     | Yes                      |
 | NVLink                    | 5.0 (1.8 TB/s)         | 5.0 (1.8 TB/s)          |
@@ -89,7 +89,7 @@ Everything at the SM level is identical to sm100:
 - 228 KB shared memory per SM
 - 64 warps/SM, 32 max blocks/SM
 - 65536 registers per SM
-- WGMMA shapes and throughput
+- tcgen05 tensor-core shapes and throughput
 - TMEM size and behavior
 - TMA descriptor format and multicast
 - Bank conflict rules
@@ -237,14 +237,14 @@ cuTensorMapEncodeTiled(
 All warp-level features are identical to sm100. See the [sm100 guide](sm100-optimization-guide.md) for:
 
 - Warp shuffle reductions
-- WGMMA / tcgen05 instructions
+- tcgen05 tensor-core instructions
 - Tensor Memory (TMEM) usage
 - Distributed Shared Memory patterns
 
-### WGMMA Quick Reference
+### tcgen05 Quick Reference
 
 ```cuda
-// WGMMA shapes (same as sm100):
+// tcgen05 tensor-core shapes (same as sm100):
 // FP16/BF16: 64x256x16, 64x128x16, 64x64x16
 // FP8:       64x256x32, 64x128x32, 64x64x32
 // FP4:       64x256x64, 64x128x64, 64x64x64

--- a/.copilot/skills/cuda-cpp-kernel/sm120-optimization-guide.md
+++ b/.copilot/skills/cuda-cpp-kernel/sm120-optimization-guide.md
@@ -33,7 +33,7 @@ Deep dive into RTX 5090 and RTX PRO 6000-specific optimizations for CUDA kernels
 3. **5th-Gen Tensor Cores** - FP4/FP8/FP16/BF16/TF32 support (same gen as datacenter Blackwell)
 4. **128 MB L2 Cache** - Massive L2 on full GB202 (PRO 6000), 96 MB on RTX 5090
 5. **PCIe Gen5 x16** - 64 GB/s bidirectional host-device bandwidth
-6. **No TMA** - Unlike datacenter sm100, sm120 lacks Tensor Memory Accelerator
+6. **TMA Support** - Unlike Ada, sm120 exposes TMA-based staging for regular bulk tensor movement
 7. **No Thread Block Clusters** - No cluster or distributed shared memory support
 8. **No TMEM** - No dedicated tensor memory; tensor operands use register file
 9. **No WGMMA/tcgen05** - Uses traditional WMMA or cuBLAS for tensor core access
@@ -53,15 +53,15 @@ Deep dive into RTX 5090 and RTX PRO 6000-specific optimizations for CUDA kernels
 | Memory bandwidth          | 1.79-1.8 TB/s        | 8 TB/s                   |
 | Thread Block Clusters     | No                   | Yes                      |
 | Distributed Shared Memory | No                   | Yes                      |
-| TMA                       | No                   | Yes (v2, multicast)      |
+| TMA                       | Yes                  | Yes (v2, multicast)      |
 | TMEM                      | No                   | Yes                      |
-| WGMMA / tcgen05           | No                   | Yes                      |
+| Warp-group / TMEM MMA path| No                   | Yes                      |
 | cp.async                  | Yes                  | Yes                      |
 | Tensor Core gen           | 5th gen              | 5th gen                  |
 | FP4 support               | Yes                  | Yes                      |
 | NVLink                    | No                   | 5.0 (1.8 TB/s)          |
 
-**sm120 is architecturally closer to Ada (sm89) than to datacenter Blackwell (sm100)** in terms of SM-level features. It has the same warp count, block limits, and lacks TMA/clusters/TMEM. The tensor cores are 5th-gen (same as sm100), and it gains GDDR7 and larger L2 over Ada.
+**sm120 is still much closer to Ada (sm89) than to datacenter Blackwell (sm100)** in warp count, block limits, and the lack of TMEM or cluster-capable execution. However, unlike Ada, sm120 also exposes TMA-backed staging for regular tiles. The tensor cores are 5th-gen (same as sm100), and it gains GDDR7 and larger L2 over Ada.
 
 ### Key Differences from Ada (sm89)
 
@@ -257,7 +257,7 @@ float val = data[threadIdx.y][threadIdx.x];
 
 ### Asynchronous Memory Copy (cp.async)
 
-sm120 supports `cp.async` (like Ada) but **not TMA**. Use `cp.async` for all async global-to-shared transfers:
+sm120 supports both `cp.async` and TMA. Use TMA for regular bulk tensor movement when descriptors and scheduling are available; use `cp.async` for fine-grained or irregular global-to-shared transfers:
 
 ```cuda
 // cp.async: bypass register file for global→shared copies
@@ -301,12 +301,12 @@ for (int k = 0; k < K; k += TILE_K) {
 }
 ```
 
-**No TMA means:**
+**When you choose `cp.async` instead of TMA:**
 
-- No hardware tensor descriptors — all addressing is manual
-- No multicast — each block must load its own copy of shared data
-- No bulk async operations — cp.async operates per-thread
-- Kernel code is simpler but less bandwidth-efficient than sm100
+- All addressing is manual at the per-thread or per-lane level
+- There is no descriptor-driven bulk movement to amortize address generation
+- Each block still loads its own copy of shared data because sm120 has no cluster multicast path
+- Kernel code is simpler, but usually less efficient than a good TMA schedule on regular tiles
 
 ## Warp-Level Optimizations
 
@@ -744,9 +744,9 @@ nsys profile -o profile_report python your_script.py
 
    - Solution: Use 256 or 512 thread blocks instead
 
-5. **No TMA overhead**: Manual address calculation per thread
+5. **TMA setup or manual staging overhead**: Descriptor setup can dominate tiny kernels, while cp.async paths pay address-generation cost
 
-   - Solution: Use cp.async with double-buffering, precompute addresses
+    - Solution: Prefer TMA for regular bulk movement, or use cp.async with double-buffering and precomputed addresses
 
 6. **VRAM limit on RTX 5090**: 32 GB constrains model size
 
@@ -785,7 +785,7 @@ nvcc -gencode arch=compute_89,code=sm_89 \
 4. **Kernel Fusion**: The single most important optimization on sm120 due to limited GDDR7 BW
 5. **Tensor Cores**: Use WMMA (not WGMMA). Watch register pressure from fragments
 6. **Block Size**: Prefer 256 threads. Avoid 1024 (caps at 67% occupancy)
-7. **No TMA/Clusters**: Use cp.async for async loads. Each block is independent
+7. **No Clusters/TMEM**: Use TMA or cp.async for async loads, but each block is still independent
 8. **Precision**: FP4 for inference weights (new on sm120), FP8 for training, BF16 for general use
 9. **Profile**: Watch memory throughput and L2 hit rate — these define the performance ceiling
 10. **Type Conversions**: Always use explicit `to_float()`/`from_float()` helpers (PyTorch disables implicit FP16/BF16 conversions)

--- a/.copilot/skills/cute-dsl-kernel/SKILL.md
+++ b/.copilot/skills/cute-dsl-kernel/SKILL.md
@@ -189,7 +189,8 @@ Use `cutlass-cpp-kernel` alongside this skill when you need C++ CUTLASS or CuTe 
 2. Use runtime printing sparingly for GPU-side debugging.
 3. Save PTX or IR when you need to inspect code generation.
 4. Reduce the problem to the smallest shape that still reproduces the failure.
-5. Once correctness is stable, profile before tuning.
+5. If the kernel relies on shared memory, `cp.async`, pipeline stages, or other asynchronous movement, treat synchronization as a primary suspect. When only specific shapes or pipeline configurations produce bad outputs, first inspect barrier placement, shared-stage reuse, and predicate coverage on partial-tile loads or stores.
+6. Once correctness is stable, profile before tuning.
 
 ## Validation Requirements
 

--- a/.copilot/skills/cutlass-cpp-kernel/SKILL.md
+++ b/.copilot/skills/cutlass-cpp-kernel/SKILL.md
@@ -101,9 +101,9 @@ Start from the most likely source family:
 
 For performance diagnosis, pair source study with the bundled architecture guides:
 
-1. On `sm89` and `sm120`, prioritize memory throughput, L2 hit rate, occupancy, and the cost of not having TMA or cluster features.
+1. On `sm89` and `sm120`, prioritize memory throughput, L2 hit rate, occupancy, and the cost of not having cluster or TMEM-backed datacenter features; on `sm120`, decide explicitly whether TMA or `cp.async` is the better staging path.
 2. On `sm90`, check whether the design is actually exploiting Hopper-specific staging and overlap opportunities.
-3. On `sm100` and `sm103`, verify that the kernel structure aligns with WGMMA, TMEM, TMA v2, and cluster-capable execution rather than only recompiling an older design.
+3. On `sm100` and `sm103`, verify that the kernel structure aligns with `tcgen05`, TMEM, TMA v2, and cluster-capable execution rather than only recompiling an older design.
 
 ## Architecture-Specific Nsight Guidance
 

--- a/.copilot/skills/cutlass-cpp-kernel/SKILL.md
+++ b/.copilot/skills/cutlass-cpp-kernel/SKILL.md
@@ -128,6 +128,8 @@ Before editing code, answer these questions:
 4. What public operator contract or wrapper must remain stable?
 5. What tests and benchmarks will prove the rewrite is valid?
 
+If the kernel uses shared memory, async-copy pipelines, TMA-like staging, or multi-stage buffering, explicitly audit synchronization before blaming layout algebra or MMA semantics. When only some shapes, stage counts, or schedule variants fail, prioritize checking barrier placement, stage-slot reuse, and predicate guards for partial tiles.
+
 If the task becomes repository integration work, move that part to `operator-migration` and keep this skill focused on kernel structure and source study.
 
 For architecture-specific bottlenecks or Nsight interpretation questions, use the bundled optimization guides as supporting reference material instead of assuming the same diagnosis applies across Ada, Hopper, and Blackwell.

--- a/.copilot/skills/cutlass-cpp-kernel/sm100-optimization-guide.md
+++ b/.copilot/skills/cutlass-cpp-kernel/sm100-optimization-guide.md
@@ -32,7 +32,7 @@ Deep dive into B200/GB200-specific optimizations for CUDA kernels.
 2. **5th-Gen Tensor Cores** - FP4/FP6/FP8/FP16/BF16/TF32 support, 2x throughput vs Hopper
 3. **Tensor Memory Accelerator (TMA)** - Enhanced over Hopper with multicast and bulk async operations
 4. **Thread Block Clusters** - Groups of thread blocks that cooperate via distributed shared memory
-5. **WGMMA (Warp Group Matrix Multiply-Accumulate)** - New instruction replacing Hopper's GMMA
+5. **tcgen05 Tensor Core MMA** - Blackwell replaces Hopper's `wgmma.mma_async` path with `tcgen05` tensor-core instructions
 6. **Tensor Memory (TMEM)** - Dedicated memory for tensor core operands, separate from register file
 7. **tcgen05** - New tensor core generation instruction set
 8. **NVFP4** - Native 4-bit floating point in tensor cores
@@ -57,7 +57,7 @@ Deep dive into B200/GB200-specific optimizations for CUDA kernels.
 | Tensor Core gen           | 5th gen              | 4th gen                  |
 | FP4 support               | Yes (NVFP4)          | No                       |
 | FP6 support               | Yes                  | No                       |
-| WGMMA / tcgen05           | Yes                  | No (uses wgmma.mma_async)|
+| tcgen05 tensor-core MMA   | Yes                  | No (uses wgmma.mma_async)|
 | Tensor Memory (TMEM)      | Yes                  | No                       |
 | NVLink                    | 5.0 (1.8 TB/s)      | 4.0 (900 GB/s)           |
 
@@ -300,35 +300,29 @@ val = max(val, max_val);
 // ... repeat for 8, 4, 2, 1
 ```
 
-### WGMMA (Warp Group Matrix Multiply-Accumulate)
+### Warp-Group Tensor Core MMA (`tcgen05`)
 
-Blackwell introduces `tcgen05` instructions that supersede Hopper's GMMA. WGMMA operates on warp groups (4 warps = 128 threads):
+Blackwell does not use Hopper's `wgmma.mma_async` instruction. Instead it introduces the `tcgen05.*` tensor-core instruction family, coupled with TMEM and TMA-based staging for warp-group style GEMM pipelines:
 
 ```cuda
-// WGMMA: Matrix multiply using Tensor Memory (TMEM)
+// Blackwell tcgen05 tensor-core flow:
 // Operand A comes from TMEM (dedicated tensor memory, not registers)
 // Operand B comes from shared memory or TMEM
 // Result accumulates in TMEM
 
 // Key advantage: TMEM is separate from the 64K register file
-// This means WGMMA doesn't consume registers for tensor operands
+// This means tcgen05 MMA doesn't consume registers for tensor operands
 
-// Typical WGMMA shapes (M x N x K):
+// Typical warp-group tensor-core shapes (M x N x K):
 // FP16/BF16: 64x256x16, 64x128x16, 64x64x16
 // FP8:       64x256x32, 64x128x32, 64x64x32
 // FP4:       64x256x64, 64x128x64, 64x64x64
 
-// WGMMA is accessed via CUTLASS or inline PTX:
-asm volatile(
-    "wgmma.mma_async.sync.aligned.m64n128k16.f32.f16.f16 "
-    "{%0, %1, %2, %3, %4, %5, %6, %7, "
-    " %8, %9, %10, %11, %12, %13, %14, %15, "
-    " %16, %17, %18, %19, %20, %21, %22, %23, "
-    " %24, %25, %26, %27, %28, %29, %30, %31}, "
-    " %32, %33, p;"
-    : /* outputs (accumulator in TMEM) */
-    : /* inputs (desc_a from TMEM, desc_b from smem) */
-);
+// Practical programming model:
+// 1. Use TMA to stage regular tiles into shared memory
+// 2. Use tcgen05.alloc / tcgen05.ld / tcgen05.cp to manage TMEM state
+// 3. Issue tcgen05.mma / tcgen05.mma.ws through CUTLASS SM100 collectives
+// 4. Commit/wait with tcgen05 fences instead of Hopper wgmma proxy ops
 ```
 
 ### Tensor Memory (TMEM)
@@ -338,9 +332,9 @@ TMEM is a new memory space dedicated to tensor core operands, separate from regi
 ```cuda
 // TMEM key properties:
 // - Not part of the 64K register file per SM
-// - Accessed exclusively by tensor cores via tcgen05/WGMMA
+// - Accessed exclusively by tensor cores via tcgen05 MMA instructions
 // - Reduces register pressure for GEMM/attention kernels
-// - Operands must be staged into TMEM before WGMMA
+// - Operands must be staged into TMEM before tcgen05 MMA
 
 // Practical impact:
 // - On Hopper: tensor operands consumed registers, limiting occupancy
@@ -416,8 +410,8 @@ For B200 kernels:
 | ------------ | ------------- | ----- | ------------------------------------------- |
 | Element-wise | 256           | 8     | High occupancy, simple workloads            |
 | Reduction    | 512-1024      | 16-32 | Enough threads for full reduction           |
-| Attention    | 128-256       | 4-8   | Balance shared mem tiles and WGMMA usage    |
-| GEMM (WGMMA) | 128           | 4     | Warp group (4 warps) is the WGMMA unit      |
+| Attention              | 128-256       | 4-8   | Balance shared mem tiles and tcgen05 usage   |
+| GEMM (tcgen05 / TMEM)  | 128           | 4     | Warp group (4 warps) is the tensor-core unit |
 
 ### Thread Block Clusters
 
@@ -488,7 +482,7 @@ Blackwell introduces native FP4 (NVFP4) and FP6 support:
 // - CUTLASS with SM100 FP4 kernel configs
 // - TensorRT-LLM quantized inference
 
-// FP4 WGMMA shape: 64x256x64 — double the K-dimension of FP8
+// FP4 tcgen05 tensor-core shape: 64x256x64 — double the K-dimension of FP8
 // This means 2x more elements processed per instruction
 ```
 
@@ -563,9 +557,9 @@ Key changes when porting kernels from H100 to B200:
 // Hopper: cluster_size = 2
 // Blackwell: cluster_size = 2-4 (better cross-block communication)
 
-// 3. Replace wgmma.mma_async with tcgen05 WGMMA
-// Hopper: wgmma.mma_async (register → smem)
-// Blackwell: tcgen05 WGMMA (TMEM → smem), frees registers
+// 3. Replace Hopper's wgmma.mma_async path with Blackwell tcgen05 MMA
+// Hopper: wgmma.mma_async with register-fragment A operands
+// Blackwell: tcgen05 MMA with TMEM-backed operands, freeing registers
 
 // 4. Use TMA multicast for shared loads across clusters
 // Hopper: each block loads its own copy
@@ -581,19 +575,19 @@ Tensor cores are the primary compute engine on Blackwell:
 
 ```cuda
 // Tensor core utilization checklist:
-// 1. Tile dimensions must be multiples of WGMMA shapes
+// 1. Tile dimensions must be multiples of tcgen05-supported shapes
 //    FP16: M=64, N=64/128/256, K=16
 //    FP8:  M=64, N=64/128/256, K=32
 //    FP4:  M=64, N=64/128/256, K=64
 
 // 2. Data must be in shared memory (for B operand) or TMEM (for A operand)
 // 3. Accumulation is always in FP32 (output is in TMEM)
-// 4. Software pipeline: overlap WGMMA with TMA loads
+// 4. Software pipeline: overlap tcgen05 MMA with TMA loads
 
 // Pipelining pattern:
 // Stage 0: TMA load tile[0] → smem
-// Stage 1: TMA load tile[1] → smem, WGMMA on tile[0]
-// Stage 2: TMA load tile[2] → smem, WGMMA on tile[1]
+// Stage 1: TMA load tile[1] → smem, tcgen05 MMA on tile[0]
+// Stage 2: TMA load tile[2] → smem, tcgen05 MMA on tile[1]
 // ...
 ```
 
@@ -645,7 +639,7 @@ python your_script.py
 # Key metrics for sm100 kernels:
 # - Achieved occupancy (max 64 warps/SM)
 # - Memory throughput (% of 8 TB/s peak)
-# - Tensor core utilization (WGMMA throughput)
+# - Tensor core utilization (tcgen05 throughput)
 # - TMA throughput
 # - L2 hit rate (126 MB L2)
 # - Cross-die traffic
@@ -654,9 +648,9 @@ python your_script.py
 
 ### Common Performance Issues
 
-1. **Underutilizing tensor cores**: Not using WGMMA/tcgen05
+1. **Underutilizing tensor cores**: Not using tcgen05/TMEM/TMA-capable kernels
 
-   - Solution: Use CUTLASS SM100 kernels or write WGMMA PTX
+    - Solution: Use CUTLASS SM100 kernels or write tcgen05 PTX/CuTe code
 
 2. **Cross-die thrashing**: Working set spans both dies inefficiently
 
@@ -706,9 +700,9 @@ nvcc -gencode arch=compute_90,code=sm_90 \
 2. **Shared Memory**: 228 KB max — increase tile sizes vs Hopper, take advantage of the extra 36 KB
 3. **L2 Cache**: 126 MB — 2.5x Hopper, use persistence hints for KV caches
 4. **TMA**: Use for all bulk global→shared transfers; multicast across clusters to reduce BW
-5. **WGMMA/tcgen05**: Use warp group MMA for all GEMM/attention — TMEM frees registers
+5. **tcgen05/TMEM**: Use Blackwell tensor-core MMA for GEMM/attention — TMEM frees registers
 6. **Clusters**: Use 2-4 block clusters for attention and stencil patterns with DSMEM
 7. **Precision**: FP4 for inference weights, FP8 for training, BF16 fallback, FP32 accumulation
-8. **Block Size**: 128-256 threads for WGMMA kernels. All sizes achieve 100% occupancy
+8. **Block Size**: 128-256 threads for tcgen05/TMEM kernels. All sizes achieve 100% occupancy
 9. **Profile**: Watch tensor core utilization and TMA throughput — these are the new bottlenecks
 10. **Type Conversions**: Always use explicit `to_float()`/`from_float()` helpers (PyTorch disables implicit FP16/BF16 conversions)

--- a/.copilot/skills/cutlass-cpp-kernel/sm103-optimization-guide.md
+++ b/.copilot/skills/cutlass-cpp-kernel/sm103-optimization-guide.md
@@ -35,7 +35,7 @@ Deep dive into B300/GB300-specific optimizations for CUDA kernels.
 5. **208B Transistors** - Dual-die design, same NVLink-C2C interconnect as B200
 6. **PCIe Gen6** - 2x PCIe Gen5 bandwidth for host-device transfers
 7. **1,400W TDP** - Higher power budget enables sustained boost clocks
-8. **Same SM microarchitecture as sm100** - WGMMA, TMEM, tcgen05, TMA v2 all carry over
+8. **Same SM microarchitecture as sm100** - tcgen05, TMEM, and TMA v2 all carry over
 
 ### Key Differences from Blackwell (sm100)
 
@@ -51,7 +51,7 @@ Deep dive into B300/GB300-specific optimizations for CUDA kernels.
 | Registers/SM              | 65536                   | 65536                    |
 | Memory bandwidth          | 8 TB/s                  | 8 TB/s                   |
 | Tensor cores per SM       | Same (5th gen)          | 5th gen                  |
-| WGMMA / tcgen05 / TMEM    | Yes                     | Yes                      |
+| tcgen05 / TMEM / TMA      | Yes                     | Yes                      |
 | TMA v2 (multicast)        | Yes                     | Yes                      |
 | Thread Block Clusters     | Yes                     | Yes                      |
 | NVLink                    | 5.0 (1.8 TB/s)         | 5.0 (1.8 TB/s)          |
@@ -89,7 +89,7 @@ Everything at the SM level is identical to sm100:
 - 228 KB shared memory per SM
 - 64 warps/SM, 32 max blocks/SM
 - 65536 registers per SM
-- WGMMA shapes and throughput
+- tcgen05 tensor-core shapes and throughput
 - TMEM size and behavior
 - TMA descriptor format and multicast
 - Bank conflict rules
@@ -237,14 +237,14 @@ cuTensorMapEncodeTiled(
 All warp-level features are identical to sm100. See the [sm100 guide](sm100-optimization-guide.md) for:
 
 - Warp shuffle reductions
-- WGMMA / tcgen05 instructions
+- tcgen05 tensor-core instructions
 - Tensor Memory (TMEM) usage
 - Distributed Shared Memory patterns
 
-### WGMMA Quick Reference
+### tcgen05 Quick Reference
 
 ```cuda
-// WGMMA shapes (same as sm100):
+// tcgen05 tensor-core shapes (same as sm100):
 // FP16/BF16: 64x256x16, 64x128x16, 64x64x16
 // FP8:       64x256x32, 64x128x32, 64x64x32
 // FP4:       64x256x64, 64x128x64, 64x64x64
@@ -410,7 +410,7 @@ The B300's 1,400W TDP (vs B200's 1,000W) allows sustained high-frequency operati
 // 3. More headroom for power-hungry FP4/FP8 tensor core operations
 
 // Practical impact:
-// - Sustained WGMMA throughput is higher (less thermal throttling)
+// - Sustained tcgen05 tensor-core throughput is higher (less thermal throttling)
 // - Memory-bound kernels benefit less (HBM BW is the same)
 // - Compute-bound kernels see the biggest gains
 
@@ -540,7 +540,7 @@ nvcc -gencode arch=compute_89,code=sm_89 \
 2. **L2 Cache**: 192 MB is the key advantage — pin KV caches, use persistence hints aggressively
 3. **Shared Memory**: 228 KB max, identical to sm100 — no tile size changes needed
 4. **HBM Capacity**: 288 GB enables larger models; reduce tensor parallelism where possible
-5. **SM Architecture**: Identical to sm100 — all WGMMA, TMEM, TMA patterns carry over directly
+5. **SM Architecture**: Identical to sm100 — all tcgen05, TMEM, and TMA patterns carry over directly
 6. **PCIe Gen6**: Use pinned memory and async transfers to exploit 128 GB/s host bandwidth
 7. **Clusters**: More SMs = more concurrent clusters. Scale cluster count with problem size
 8. **Precision**: Same FP4/FP6/FP8/FP16/BF16 support as sm100

--- a/.copilot/skills/cutlass-cpp-kernel/sm120-optimization-guide.md
+++ b/.copilot/skills/cutlass-cpp-kernel/sm120-optimization-guide.md
@@ -33,7 +33,7 @@ Deep dive into RTX 5090 and RTX PRO 6000-specific optimizations for CUDA kernels
 3. **5th-Gen Tensor Cores** - FP4/FP8/FP16/BF16/TF32 support (same gen as datacenter Blackwell)
 4. **128 MB L2 Cache** - Massive L2 on full GB202 (PRO 6000), 96 MB on RTX 5090
 5. **PCIe Gen5 x16** - 64 GB/s bidirectional host-device bandwidth
-6. **No TMA** - Unlike datacenter sm100, sm120 lacks Tensor Memory Accelerator
+6. **TMA Support** - Unlike Ada, sm120 exposes TMA-based staging in modern CUTLASS/CuTe kernels
 7. **No Thread Block Clusters** - No cluster or distributed shared memory support
 8. **No TMEM** - No dedicated tensor memory; tensor operands use register file
 9. **No WGMMA/tcgen05** - Uses traditional WMMA or cuBLAS for tensor core access
@@ -53,15 +53,15 @@ Deep dive into RTX 5090 and RTX PRO 6000-specific optimizations for CUDA kernels
 | Memory bandwidth          | 1.79-1.8 TB/s        | 8 TB/s                   |
 | Thread Block Clusters     | No                   | Yes                      |
 | Distributed Shared Memory | No                   | Yes                      |
-| TMA                       | No                   | Yes (v2, multicast)      |
+| TMA                       | Yes                  | Yes (v2, multicast)      |
 | TMEM                      | No                   | Yes                      |
-| WGMMA / tcgen05           | No                   | Yes                      |
+| Warp-group / TMEM MMA path| No                   | Yes                      |
 | cp.async                  | Yes                  | Yes                      |
 | Tensor Core gen           | 5th gen              | 5th gen                  |
 | FP4 support               | Yes                  | Yes                      |
 | NVLink                    | No                   | 5.0 (1.8 TB/s)          |
 
-**sm120 is architecturally closer to Ada (sm89) than to datacenter Blackwell (sm100)** in terms of SM-level features. It has the same warp count, block limits, and lacks TMA/clusters/TMEM. The tensor cores are 5th-gen (same as sm100), and it gains GDDR7 and larger L2 over Ada.
+**sm120 is still much closer to Ada (sm89) than to datacenter Blackwell (sm100)** in warp count, block limits, and the lack of TMEM or cluster-capable execution. However, unlike Ada, sm120 also exposes TMA-backed mainloops/epilogues in modern CUTLASS kernels. The tensor cores are 5th-gen (same as sm100), and it gains GDDR7 and larger L2 over Ada.
 
 ### Key Differences from Ada (sm89)
 
@@ -257,7 +257,7 @@ float val = data[threadIdx.y][threadIdx.x];
 
 ### Asynchronous Memory Copy (cp.async)
 
-sm120 supports `cp.async` (like Ada) but **not TMA**. Use `cp.async` for all async global-to-shared transfers:
+sm120 supports both `cp.async` and TMA. Use TMA for regular bulk tensor movement when CUTLASS/CuTe can supply descriptors and scheduling; use `cp.async` for fine-grained or irregular global-to-shared transfers:
 
 ```cuda
 // cp.async: bypass register file for global→shared copies
@@ -301,12 +301,12 @@ for (int k = 0; k < K; k += TILE_K) {
 }
 ```
 
-**No TMA means:**
+**When you choose `cp.async` instead of TMA:**
 
-- No hardware tensor descriptors — all addressing is manual
-- No multicast — each block must load its own copy of shared data
-- No bulk async operations — cp.async operates per-thread
-- Kernel code is simpler but less bandwidth-efficient than sm100
+- All addressing is manual at the per-thread or per-lane level
+- There is no descriptor-driven bulk movement to amortize address generation
+- Each block still loads its own copy of shared data because sm120 has no cluster multicast path
+- Kernel code is simpler, but usually less efficient than a good TMA schedule on regular tiles
 
 ## Warp-Level Optimizations
 
@@ -362,7 +362,7 @@ wmma::store_matrix_sync(&smem_c[warp_row * 16 + warp_col * 16 * ldc],
                          c_frag, ldc, wmma::mem_row_major);
 ```
 
-**Key differences from sm100 WGMMA:**
+**Key differences from sm100 tcgen05/TMEM kernels:**
 
 ```cuda
 // WMMA (sm120):
@@ -372,7 +372,7 @@ wmma::store_matrix_sync(&smem_c[warp_row * 16 + warp_col * 16 * ldc],
 // - Simpler programming model
 // - No TMEM — tensor operands use registers
 
-// WGMMA (sm100):
+// tcgen05/TMEM path (sm100):
 // - Operates on a warp group (128 threads / 4 warps)
 // - Operands in TMEM (doesn't consume registers)
 // - Larger tile sizes (64x256x16)
@@ -540,17 +540,17 @@ sm120 is the natural upgrade path from sm89. Key improvements to leverage:
 Datacenter kernels need significant adaptation:
 
 ```cuda
-// 1. Replace TMA with cp.async
-// sm100 (TMA):
-//   cuTensorMapEncodeTiled(...);  // Hardware descriptor
-//   cp.async.bulk.tensor...       // Single instruction loads tile
+// 1. Re-evaluate the staging path
+// sm100 (TMA + cluster-capable):
+//   cuTensorMapEncodeTiled(...);
+//   cluster-aware TMA schedules + multicast are common
 //
-// sm120 (cp.async):
-//   Manual address calculation per thread
-//   __pipeline_memcpy_async per element
-//   More code, fewer features
+// sm120 (TMA or cp.async):
+//   TMA still exists for regular tiles
+//   cp.async remains useful for irregular/manual staging
+//   There is no sm100-style cluster multicast path
 
-// 2. Replace WGMMA with WMMA
+// 2. Replace tcgen05/TMEM tensor-core mainloops with WMMA/register-fragment mainloops
 // sm100: warp group (128 threads), 64x256x16 tiles, TMEM operands
 // sm120: single warp (32 threads), 16x16x16 tiles, register operands
 //
@@ -744,9 +744,9 @@ nsys profile -o profile_report python your_script.py
 
    - Solution: Use 256 or 512 thread blocks instead
 
-5. **No TMA overhead**: Manual address calculation per thread
+5. **TMA setup or manual staging overhead**: Descriptor setup can dominate tiny kernels, while cp.async paths pay address-generation cost
 
-   - Solution: Use cp.async with double-buffering, precompute addresses
+    - Solution: Prefer TMA for regular bulk movement, or use cp.async with double-buffering and precomputed addresses
 
 6. **VRAM limit on RTX 5090**: 32 GB constrains model size
 
@@ -785,7 +785,7 @@ nvcc -gencode arch=compute_89,code=sm_89 \
 4. **Kernel Fusion**: The single most important optimization on sm120 due to limited GDDR7 BW
 5. **Tensor Cores**: Use WMMA (not WGMMA). Watch register pressure from fragments
 6. **Block Size**: Prefer 256 threads. Avoid 1024 (caps at 67% occupancy)
-7. **No TMA/Clusters**: Use cp.async for async loads. Each block is independent
+7. **No Clusters/TMEM**: Use TMA or cp.async for async loads, but each block is still independent
 8. **Precision**: FP4 for inference weights (new on sm120), FP8 for training, BF16 for general use
 9. **Profile**: Watch memory throughput and L2 hit rate — these define the performance ceiling
 10. **Type Conversions**: Always use explicit `to_float()`/`from_float()` helpers (PyTorch disables implicit FP16/BF16 conversions)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <p align="center">
     <h2 align="center">
       <img src=https://github.com/vipshop/cache-dit/raw/main/assets/cache-dit-logo-v2.png width=185px align="left">
-      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism and Quantization for Diffusion<br>
+      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism and Quantization for Diffusion Transformers<br>
       <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
       <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
       <img src="https://img.shields.io/github/license/vipshop/cache-dit.svg?color=blue">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <p align="center">
     <h2 align="center">
       <img src=https://github.com/vipshop/cache-dit/raw/main/assets/cache-dit-logo-v2.png width=185px align="left">
-      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism and Quantization for Diffusion Transformers<br>
+      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers<br>
       <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
       <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
       <img src="https://img.shields.io/github/license/vipshop/cache-dit.svg?color=blue">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <p align="center">
     <h2 align="center">
       <img src=https://github.com/vipshop/cache-dit/raw/main/assets/cache-dit-logo-v2.png width=185px align="left">
-      🤗🎉A PyTorch-native Inference Engine with Hybrid <br>Cache Acceleration and Massive Parallelism for DiTs<br>
+      ⚡️🎉A PyTorch-native inference engine with Cache<br>Parallelism and Quantization for Diffusion Transformers<br>
       <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
       <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
       <img src="https://img.shields.io/github/license/vipshop/cache-dit.svg?color=blue">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <p align="center">
     <h2 align="center">
       <img src=https://github.com/vipshop/cache-dit/raw/main/assets/cache-dit-logo-v2.png width=185px align="left">
-      ⚡️🎉A PyTorch-native inference engine with Cache<br>Parallelism and Quantization for Diffusion Transformers<br>
+      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism and Quantization for Diffusion<br>
       <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
       <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
       <img src="https://img.shields.io/github/license/vipshop/cache-dit.svg?color=blue">

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Special thanks to vipshop's Computer Vision AI Team for supporting testing and d
 
 ```BibTeX
 @misc{cache-dit@2025,
-  title={Cache-DiT: A PyTorch-native Inference Engine with Hybrid Cache Acceleration and Massive Parallelism for DiTs.},
+  title={Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
   url={https://github.com/vipshop/cache-dit.git},
   note={Open-source software available at https://github.com/vipshop/cache-dit.git},
   author={DefTruth, vipshop.com, etc.},

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <p align="center">
     <h2 align="center">
       <img src=https://github.com/vipshop/cache-dit/raw/main/assets/cache-dit-logo-v2.png width=185px align="left">
-      ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers<br>
+      ⚡️🎉A PyTorch-native Inference Engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers<br>
       <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
       <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
       <img src="https://img.shields.io/github/license/vipshop/cache-dit.svg?color=blue">
@@ -116,7 +116,7 @@ Special thanks to vipshop's Computer Vision AI Team for supporting testing and d
 
 ```BibTeX
 @misc{cache-dit@2025,
-  title={Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
+  title={Cache-DiT: A PyTorch-native Inference Engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
   url={https://github.com/vipshop/cache-dit.git},
   note={Open-source software available at https://github.com/vipshop/cache-dit.git},
   author={DefTruth, vipshop.com, etc.},

--- a/bench/kernels/bench_svdq_runtime.py
+++ b/bench/kernels/bench_svdq_runtime.py
@@ -332,6 +332,7 @@ def main() -> None:
     },
   }
   json_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+  os.environ.pop("CACHE_DIT_SVDQ_V2_BLOCK_M", None)
   print(json.dumps(summary, indent=2, sort_keys=True))
 
 

--- a/bench/kernels/bench_svdq_runtime_focus.py
+++ b/bench/kernels/bench_svdq_runtime_focus.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+
+from cache_dit.kernels import svdq_gemm_w4a4
+from cache_dit.kernels import svdq_gemm_w4a4_v2
+from cache_dit.kernels import svdq_quantize_w4a4_act_fuse_lora
+from cache_dit.kernels import svdq_quantize_w4a4_wgt
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+  """Parse CLI arguments for the focused runtime benchmark harness.
+
+  :returns: Parsed CLI arguments.
+  """
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--runtime-kernel", choices=("v1", "v2"), default="v2")
+  parser.add_argument("--seq-len", type=int, default=4096)
+  parser.add_argument("--embed-dim", type=int, default=4096)
+  parser.add_argument("--rank", type=int, default=32)
+  parser.add_argument("--stage", type=int, default=1)
+  parser.add_argument("--block-m", type=int, choices=(64, 128, 256), default=128)
+  parser.add_argument("--warmup", type=int, default=20)
+  parser.add_argument("--iters", type=int, default=100)
+  parser.add_argument(
+    "--output",
+    type=Path,
+    default=None,
+    help="Optional JSON output path. Defaults to stdout-only when omitted.",
+  )
+  return parser.parse_args()
+
+
+def runtime_dtype() -> torch.dtype:
+  """Return the CUDA runtime dtype used by the benchmark.
+
+  :returns: `torch.bfloat16` when supported, otherwise `torch.float16`.
+  """
+
+  return (torch.bfloat16
+          if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else torch.float16)
+
+
+def benchmark(op, kwargs: dict[str, object], *, warmup: int, iters: int) -> dict[str, object]:
+  """Benchmark a single CUDA op.
+
+  :param op: Callable kernel wrapper to benchmark.
+  :param kwargs: Keyword arguments forwarded to the callable.
+  :param warmup: Warmup iteration count.
+  :param iters: Timed iteration count.
+  :returns: Dict containing latency, peak memory, and output tensor.
+  """
+
+  torch.cuda.synchronize()
+  out = None
+  for _ in range(warmup):
+    out = op(**kwargs)
+  torch.cuda.synchronize()
+  torch.cuda.reset_peak_memory_stats()
+  start = torch.cuda.Event(enable_timing=True)
+  end = torch.cuda.Event(enable_timing=True)
+  start.record()
+  for _ in range(iters):
+    out = op(**kwargs)
+  end.record()
+  torch.cuda.synchronize()
+  assert out is not None
+  return {
+    "latency_ms": start.elapsed_time(end) / iters,
+    "peak_mem_mb": torch.cuda.max_memory_allocated() / (1024 ** 2),
+    "output": out,
+  }
+
+
+def select_kernel(runtime_kernel: str):
+  """Return the requested runtime kernel wrapper.
+
+  :param runtime_kernel: Public runtime kernel name.
+  :returns: Callable kernel wrapper.
+  """
+
+  if runtime_kernel == "v1":
+    return svdq_gemm_w4a4
+  return svdq_gemm_w4a4_v2
+
+
+def maybe_set_block_env(runtime_kernel: str, block_m: int) -> tuple[str, str | None]:
+  """Set the runtime BLOCK_M override for v2/v3 while preserving the previous value.
+
+  :param runtime_kernel: Public runtime kernel name.
+  :param block_m: Logical block-M override.
+  :returns: Tuple of `(env_name, previous_value)`.
+  """
+
+  if runtime_kernel != "v2":
+    return "", None
+  env_name = "CACHE_DIT_SVDQ_V2_BLOCK_M"
+
+  previous = os.environ.get(env_name)
+  os.environ[env_name] = str(block_m)
+  return env_name, previous
+
+
+def restore_block_env(env_name: str, previous: str | None) -> None:
+  """Restore the benchmark-time BLOCK_M override.
+
+  :param env_name: Environment variable name.
+  :param previous: Previous value before override.
+  """
+
+  if not env_name:
+    return
+  if previous is None:
+    os.environ.pop(env_name, None)
+  else:
+    os.environ[env_name] = previous
+
+
+def main() -> None:
+  """Run a focused single-shape runtime benchmark and optionally export JSON.
+
+  The harness is intended for Nsight Systems and Nsight Compute collection, so it only benchmarks
+  one runtime kernel / shape combination per invocation.
+  """
+
+  args = parse_args()
+  if not torch.cuda.is_available():
+    raise RuntimeError("CUDA is required for this benchmark.")
+
+  device = torch.device("cuda")
+  dtype = runtime_dtype()
+  torch.manual_seed(0)
+
+  activations = torch.randn(args.seq_len, args.embed_dim, device=device, dtype=dtype)
+  smooth = torch.ones(args.embed_dim, device=device, dtype=dtype)
+  lora_down = torch.randn(args.embed_dim, args.rank, device=device, dtype=dtype) * 0.01
+  lora_up = torch.randn(args.embed_dim, args.rank, device=device, dtype=dtype) * 0.01
+  bias = torch.randn(args.embed_dim, device=device, dtype=dtype) * 0.01
+
+  qact, ascales, lora_act = svdq_quantize_w4a4_act_fuse_lora(
+    input=activations,
+    lora_down=lora_down,
+    smooth=smooth,
+    fp4=False,
+    pad_size=256,
+  )
+  qweight, wscales = svdq_quantize_w4a4_wgt(
+    torch.randn(args.embed_dim, args.embed_dim, device=device, dtype=dtype))
+
+  kernel = select_kernel(args.runtime_kernel)
+  kwargs: dict[str, object] = {
+    "act": qact,
+    "wgt": qweight,
+    "ascales": ascales,
+    "wscales": wscales,
+    "lora_act_in": lora_act,
+    "lora_up": lora_up,
+    "bias": bias,
+    "act_unsigned": False,
+    "fp4": False,
+    "alpha": 1.0,
+    "output_dtype": dtype,
+  }
+  if args.runtime_kernel == "v2":
+    kwargs["stage"] = args.stage
+
+  env_name, previous = maybe_set_block_env(args.runtime_kernel, args.block_m)
+  try:
+    result = benchmark(kernel, kwargs, warmup=args.warmup, iters=args.iters)
+  finally:
+    restore_block_env(env_name, previous)
+
+  summary = {
+    "runtime_kernel": args.runtime_kernel,
+    "shape": {
+      "M": args.seq_len,
+      "N": args.embed_dim,
+      "K": args.embed_dim,
+      "rank": args.rank,
+    },
+    "stage": args.stage if args.runtime_kernel == "v2" else None,
+    "block_m": args.block_m if args.runtime_kernel == "v2" else None,
+    "warmup": args.warmup,
+    "iters": args.iters,
+    "dtype": str(dtype),
+    "latency_ms": result["latency_ms"],
+    "peak_mem_mb": result["peak_mem_mb"],
+  }
+
+  if args.output is not None:
+    output_path = args.output
+    if not output_path.is_absolute():
+      output_path = REPO_ROOT / output_path
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+  print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+  main()

--- a/csrc/kernels/svdq/gemm_base.cuh
+++ b/csrc/kernels/svdq/gemm_base.cuh
@@ -353,7 +353,8 @@ class GEMMBase : public Config {
 
   // get {k}-th and {k+1}-th wscale from the block, k must be multiples of 2, k must be uniform
   // across all lanes
-  __device__ __forceinline__ static half2_t broadcast_wscale(wscale_warp block, int k, int laneId) {
+  __device__ __forceinline__ static half2_t broadcast_wscale(const wscale_warp &block, int k,
+                                                             int laneId) {
     const int packIdx = k / (WSCALES_PACK_SIZE * WARP_SIZE);
     const int srcLane = 4 * (k / WSCALES_PACK_SIZE) + laneId % 4;
     const int elementIdx = k % WSCALES_PACK_SIZE / 2;
@@ -361,7 +362,8 @@ class GEMMBase : public Config {
   }
   // get {k}-th and {k+1}-th ascale from the block, k must be multiples of 2, k must be uniform
   // across all lanes
-  __device__ __forceinline__ static half2_t broadcast_ascale(ascale_warp block, int k, int laneId) {
+  __device__ __forceinline__ static half2_t broadcast_ascale(const ascale_warp &block, int k,
+                                                             int laneId) {
     const int packIdx = k / (ASCALES_PACK_SIZE * WARP_SIZE);
     const int srcLane = 8 * (k / ASCALES_PACK_SIZE) + laneId / 4;
     const int elementIdx = k % ASCALES_PACK_SIZE / 2;
@@ -379,8 +381,9 @@ class GEMMBase : public Config {
   };
 
   template <typename i2f = i2f_normal, typename F>
-  __device__ __forceinline__ static void apply_scales(F &&getpsum, ascale_warp ascale,
-                                                      wscale_warp wscale, fpsum_warp &fpsum) {
+  __device__ __forceinline__ static void apply_scales(F &&getpsum, const ascale_warp &ascale,
+                                                      const wscale_warp &wscale,
+                                                      fpsum_warp &fpsum) {
     const int laneId = threadIdx.x % WARP_SIZE;
     const int warpId = threadIdx.x / WARP_SIZE;
 
@@ -427,8 +430,9 @@ class GEMMBase : public Config {
   }
 
   template <typename i2f = i2f_normal, typename F>
-  __device__ __forceinline__ static void apply_scales(F &&getpsum, ascale_warp ascale,
-                                                      wscale_warp wscale, f32psum_warp &fpsum) {
+  __device__ __forceinline__ static void apply_scales(F &&getpsum, const ascale_warp &ascale,
+                                                      const wscale_warp &wscale,
+                                                      f32psum_warp &fpsum) {
     const int laneId = threadIdx.x % WARP_SIZE;
     const int warpId = threadIdx.x / WARP_SIZE;
 

--- a/csrc/kernels/svdq/gemm_w4a4.cuh
+++ b/csrc/kernels/svdq/gemm_w4a4.cuh
@@ -683,8 +683,9 @@ class GEMM_W4A4<GEMMConfig_W4A4_FP16> : public GEMMBase<GEMMConfig_W4A4_FP16> {
   };
 
   template <bool ACT_UNSIGNED, typename T>
-  __device__ __forceinline__ static void compute(act_warp A, wgt_warp W, ascale_warp ascale,
-                                                 wscale_warp wscale, T &fpsum) {
+  __device__ __forceinline__ static void compute(const act_warp &A, const wgt_warp &W,
+                                                 const ascale_warp &ascale,
+                                                 const wscale_warp &wscale, T &fpsum) {
 #if defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 800
     using int2half2 = i2f_sm80;
 #elif defined(__CUDA_ARCH__) && __CUDA_ARCH__ == 750

--- a/csrc/kernels/svdq/gemm_w4a4_v2.cuh
+++ b/csrc/kernels/svdq/gemm_w4a4_v2.cuh
@@ -107,7 +107,10 @@ class GEMM_W4A4_V2 : public GEMM_W4A4<Config> {
   using Base::packed_fp16_to_fp32;
   using Base::packed_fp32_to_fp16;
 
-  struct SharedStorage {};
+  struct SharedStorage {
+    alignas(16) packed_act_t act_tiles[NUM_PIPELINE_STAGES][NUM_WARPS * WARP_M_TILES * WARP_SIZE];
+    alignas(16) packed_wgt_t wgt_tiles[NUM_PIPELINE_STAGES][WARP_N_TILES * WARP_SIZE];
+  };
 
   __device__ __forceinline__ static int packed_block_index(int logical_block_m) {
     return logical_block_m / LOGICAL_BLOCKS_PER_PACKED_BLOCK;
@@ -186,6 +189,70 @@ class GEMM_W4A4_V2 : public GEMM_W4A4<Config> {
   template <typename Warp>
   __device__ __forceinline__ static void clear_warp(Warp &warp) {
     warp = {};
+  }
+
+  __device__ __forceinline__ static int act_shared_offset(int warpId, int tile, int laneId) {
+    return ((warpId * WARP_M_TILES + tile) * WARP_SIZE) + laneId;
+  }
+
+  __device__ __forceinline__ static int wgt_shared_offset(int tile, int laneId) {
+    return (tile * WARP_SIZE) + laneId;
+  }
+
+  __device__ __forceinline__ static void prefetch_act_compat_to_shared(
+    SharedStorage &shared, int stage_slot, const packed_act_t *ptr, int logical_block_m, int k,
+    int K, bool pred) {
+    const int laneId = threadIdx.x % WARP_SIZE;
+    const int warpId = threadIdx.x / WARP_SIZE;
+    const int packed_bm = packed_block_index(logical_block_m);
+    const int packed_warp = packed_warp_base(logical_block_m) + warpId;
+
+#pragma unroll
+    for (int tile = 0; tile < WARP_M_TILES; tile++) {
+      const int shared_offset = act_shared_offset(warpId, tile, laneId);
+      const packed_act_t *src =
+        &ptr[(((packed_bm * (K / WARP_K) + k) * PACKED_NUM_WARPS + packed_warp) * WARP_M_TILES +
+               tile) *
+                WARP_SIZE +
+              laneId];
+      cp_async_ca(&shared.act_tiles[stage_slot][shared_offset], src, pred);
+    }
+  }
+
+  __device__ __forceinline__ static void prefetch_wgt_to_shared(
+    SharedStorage &shared, int stage_slot, const packed_wgt_t *ptr, int k, int K, bool pred) {
+    const int laneId = threadIdx.x % WARP_SIZE;
+    unused_var(K, false);
+
+#pragma unroll
+    for (int tile = 0; tile < WARP_N_TILES; tile++) {
+      const int shared_offset = wgt_shared_offset(tile, laneId);
+      const packed_wgt_t *src = &ptr[(k * WARP_N_TILES + tile) * WARP_SIZE + laneId];
+      cp_async_ca(&shared.wgt_tiles[stage_slot][shared_offset], src, pred);
+    }
+  }
+
+  __device__ __forceinline__ static void load_act_from_shared(const SharedStorage &shared,
+                                                              int stage_slot,
+                                                              act_warp &out) {
+    const int laneId = threadIdx.x % WARP_SIZE;
+    const int warpId = threadIdx.x / WARP_SIZE;
+
+#pragma unroll
+    for (int tile = 0; tile < WARP_M_TILES; tile++) {
+      out[tile] = load<true>(&shared.act_tiles[stage_slot][act_shared_offset(warpId, tile, laneId)]);
+    }
+  }
+
+  __device__ __forceinline__ static void load_wgt_from_shared(const SharedStorage &shared,
+                                                              int stage_slot,
+                                                              wgt_warp &out) {
+    const int laneId = threadIdx.x % WARP_SIZE;
+
+#pragma unroll
+    for (int tile = 0; tile < WARP_N_TILES; tile++) {
+      out[tile] = load<true>(&shared.wgt_tiles[stage_slot][wgt_shared_offset(tile, laneId)]);
+    }
   }
 
   __device__ __forceinline__ static void load_act_compat_safe(const packed_act_t *ptr,
@@ -325,9 +392,77 @@ class GEMM_W4A4_V2 : public GEMM_W4A4<Config> {
   }
 
   template <typename Epilogue, bool ACT_UNSIGNED>
+  __device__ __forceinline__ static void gemm_w4a4_v2_block_compat_smem(
+    SharedStorage &shared, const BlockInfo binfo, const packed_act_t *act,
+    const packed_wgt_t *wgt, const packed_ascale_t *ascales, const packed_wscale_t *wscales,
+    int M, int N, int K, const typename Epilogue::Arguments &epilogueArgs, bool alwaysfalse) {
+    fpsum_warp fpsum;
+
+    for (auto &pack : fpsum) {
+      for (int i = 0; i < 4; i++) {
+        pack.data[i].x = 0;
+        pack.data[i].y = 0;
+      }
+    }
+
+    const int num_k_tiles = K / WARP_K;
+    const int preload_stages = min(NUM_PIPELINE_STAGES, num_k_tiles);
+
+    for (int stage = 0; stage < preload_stages; stage++) {
+      prefetch_act_compat_to_shared(shared, stage, act, binfo.bm, stage, K, true);
+      prefetch_wgt_to_shared(shared, stage, wgt, stage, K, true);
+      cp_async_commit();
+    }
+
+    if (preload_stages > 0) {
+      cp_async_wait<0>();
+      __syncthreads();
+    }
+
+    for (int k = 0; k < num_k_tiles; k++) {
+      const int stage_slot = k % NUM_PIPELINE_STAGES;
+      const int nextk = k + NUM_PIPELINE_STAGES;
+      {
+        act_warp current_act;
+        wgt_warp current_wgt;
+        load_act_from_shared(shared, stage_slot, current_act);
+        load_wgt_from_shared(shared, stage_slot, current_wgt);
+
+        // All warps must finish consuming the current shared-memory stage before any
+        // warp starts overwriting the same stage slot with the next tile.
+        __syncthreads();
+
+        if (nextk < num_k_tiles) {
+          prefetch_act_compat_to_shared(shared, stage_slot, act, binfo.bm, nextk, K, true);
+          prefetch_wgt_to_shared(shared, stage_slot, wgt, nextk, K, true);
+          cp_async_commit();
+        }
+
+        ascale_warp current_ascale;
+        wscale_warp current_wscale;
+        load_ascale_compat_safe(ascales, binfo.bm, k, K, current_ascale, true);
+        load_wscale_safe(wscales, k, N, current_wscale, true);
+
+        Parent::template compute<ACT_UNSIGNED>(
+          current_act, current_wgt, current_ascale, current_wscale, fpsum);
+      }
+
+      if (nextk < num_k_tiles) {
+        cp_async_wait<0>();
+        __syncthreads();
+      }
+    }
+
+    unused_var(alwaysfalse, alwaysfalse);
+    CHECK_NAN(fpsum, "fpsum_v2_compat_smem");
+    Epilogue()(binfo, fpsum, M, N, K, epilogueArgs);
+  }
+
+  template <typename Epilogue, bool ACT_UNSIGNED>
   struct gemm_w4a4_v2_kernel {
     static constexpr int MIN_ARCH = 750;
     using SharedStorage = typename GEMM_W4A4_V2<Config, NumPipelineStages>::SharedStorage;
+    static constexpr bool USE_COMPAT_SMEM_OPT = false;
 
     __device__ void operator()(SharedStorage &shared, const packed_act_t *act,
                                const packed_wgt_t *wgt,
@@ -351,18 +486,34 @@ class GEMM_W4A4_V2 : public GEMM_W4A4<Config> {
 
       (void)shared;
       if constexpr (USE_PACKED_LAYOUT_COMPAT) {
-        GEMM_W4A4_V2<Config, NumPipelineStages>::template gemm_w4a4_v2_block_compat<
-          Epilogue, ACT_UNSIGNED>(
-          binfo,
-          act,
-          wgt + bn * (K / WARP_K) * WARP_N_TILES * WARP_SIZE,
-          ascales,
-          wscales + bn * (K / WARP_K) * WSCALES_NUM_PACKS * WSCALES_VALID_LANES,
-          M,
-          N,
-          K,
-          epilogueArgs,
-          alwaysfalse);
+        if constexpr (USE_COMPAT_SMEM_OPT && NumPipelineStages >= 2) {
+          GEMM_W4A4_V2<Config, NumPipelineStages>::template gemm_w4a4_v2_block_compat_smem<
+            Epilogue, ACT_UNSIGNED>(
+            shared,
+            binfo,
+            act,
+            wgt + bn * (K / WARP_K) * WARP_N_TILES * WARP_SIZE,
+            ascales,
+            wscales + bn * (K / WARP_K) * WSCALES_NUM_PACKS * WSCALES_VALID_LANES,
+            M,
+            N,
+            K,
+            epilogueArgs,
+            alwaysfalse);
+        } else {
+          GEMM_W4A4_V2<Config, NumPipelineStages>::template gemm_w4a4_v2_block_compat<
+            Epilogue, ACT_UNSIGNED>(
+            binfo,
+            act,
+            wgt + bn * (K / WARP_K) * WARP_N_TILES * WARP_SIZE,
+            ascales,
+            wscales + bn * (K / WARP_K) * WSCALES_NUM_PACKS * WSCALES_VALID_LANES,
+            M,
+            N,
+            K,
+            epilogueArgs,
+            alwaysfalse);
+        }
       } else {
         Parent::template gemm_w4a4_block<Epilogue, ACT_UNSIGNED, false>(
           binfo,

--- a/csrc/kernels/svdq/ops.h
+++ b/csrc/kernels/svdq/ops.h
@@ -56,11 +56,16 @@ inline void gemm_w4a4_v2(std::optional<torch::Tensor> act, std::optional<torch::
                          std::optional<torch::Tensor> lora_up,
                          std::optional<torch::Tensor> bias, bool fp4, float alpha,
                          std::optional<torch::Tensor> wcscales, bool act_unsigned,
-                         int stage = 2) {
+                         int stage = 1) {
   if (fp4) {
     throw std::runtime_error(
       "svdq_gemm_w4a4_v2 currently supports the INT4 runtime path only.");
   }
+
+  // Ada-class GPUs such as L20 keep this plain v2 path register-bound. `stage=1`
+  // is the public default because it preserves the best occupancy for the hot
+  // runtime shapes, while higher stage counts remain available for explicit
+  // profiling and follow-up experiments.
 
   TorchOpContext ctx;
   spdlog::trace("running gemm_w4a4_v2:");

--- a/csrc/kernels/svdq/pybind.cpp
+++ b/csrc/kernels/svdq/pybind.cpp
@@ -25,7 +25,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, module) {
          py::arg("alpha"),
          py::arg("wcscales"),
          py::arg("act_unsigned"),
-         py::arg("stage") = 2)
+         py::arg("stage") = 1)
     .def("quantize_w4a4_act_fuse_lora", &svdq::ops::quantize_w4a4_act_fuse_lora)
     .def("quantize_w4a4_wgt", &svdq::ops::quantize_w4a4_wgt);
 

--- a/csrc/kernels/svdq/zgemm.h
+++ b/csrc/kernels/svdq/zgemm.h
@@ -34,7 +34,8 @@ void gemm_w4a4(Tensor act,             // packed act [M, K / 2]
                int attn_tokens);
 void gemm_w4a4_v2(Tensor act, Tensor wgt, Tensor out, Tensor ascales, Tensor wscales,
                   Tensor lora_act_in, Tensor lora_up, Tensor bias, bool act_unsigned,
-                  float alpha, Tensor wcscales, int stage = 2);
+                  float alpha, Tensor wcscales,
+                  int stage = 1);  // Ada/L20 is reg-bound here, so `stage=1` keeps the best occupancy.
 void linearattn_vk_mul_q(Tensor q, Tensor vk);
 
 void quantize_w4a4_act_fuse_lora(Tensor input, Tensor output, Tensor oscales, Tensor lora_down,

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p align="center">
     <h2 align="center">
-        🤗🎉Cache-DiT: A PyTorch-native Inference Engine with <br>Hybrid Cache Acceleration and Massive Parallelism for DiTs 
+        ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
     </h2>
     <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
     <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
@@ -121,7 +121,7 @@ Special thanks to vipshop's Computer Vision AI Team for supporting testing and d
 
 ```BibTeX
 @misc{cache-dit@2025,
-  title={Cache-DiT: A PyTorch-native Inference Engine with Hybrid Cache Acceleration and Massive Parallelism for DiTs.},
+  title={Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
   url={https://github.com/vipshop/cache-dit.git},
   note={Open-source software available at https://github.com/vipshop/cache-dit.git},
   author={DefTruth, vipshop.com, etc.},

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p align="center">
     <h2 align="center">
-        ⚡️🎉A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
+        ⚡️🎉A PyTorch-native Inference Engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
     </h2>
     <a href="https://pepy.tech/projects/cache-dit"><img src=https://static.pepy.tech/personalized-badge/cache-dit?period=total&units=ABBREVIATION&left_color=GRAY&right_color=BLUE&left_text=downloads/pypi ></a>
     <a href="https://pypi.org/project/cache-dit/"><img src=https://img.shields.io/github/release/vipshop/cache-dit.svg?color=GREEN ></a>
@@ -121,7 +121,7 @@ Special thanks to vipshop's Computer Vision AI Team for supporting testing and d
 
 ```BibTeX
 @misc{cache-dit@2025,
-  title={Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
+  title={Cache-DiT: A PyTorch-native Inference Engine with Cache, Parallelism and Quantization for Diffusion Transformers.},
   url={https://github.com/vipshop/cache-dit.git},
   note={Open-source software available at https://github.com/vipshop/cache-dit.git},
   author={DefTruth, vipshop.com, etc.},

--- a/docs/user_guide/OVERVIEWS.md
+++ b/docs/user_guide/OVERVIEWS.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p align="center">
     <h2 align="center">
-        🤗🎉Cache-DiT: A PyTorch-native Inference Engine with <br>Hybrid Cache Acceleration and Massive Parallelism for DiTs
+        ⚡️🎉Cache-DiT: A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
     </h2>
   </p>
 <img src=https://github.com/vipshop/cache-dit/raw/main/assets/speedup_v4.png>

--- a/docs/user_guide/OVERVIEWS.md
+++ b/docs/user_guide/OVERVIEWS.md
@@ -1,7 +1,7 @@
 <div align="center">
   <p align="center">
     <h2 align="center">
-        ⚡️🎉Cache-DiT: A PyTorch-native inference engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
+        ⚡️🎉Cache-DiT: A PyTorch-native Inference Engine with Cache, <br>Parallelism, Quantization for Diffusion Transformers
     </h2>
   </p>
 <img src=https://github.com/vipshop/cache-dit/raw/main/assets/speedup_v4.png>

--- a/docs/user_guide/QUANTIZATION.md
+++ b/docs/user_guide/QUANTIZATION.md
@@ -354,26 +354,13 @@ quant_config = QuantizeConfig(
 pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
 ```
 
-<span style="color:green;">Step 3</span>: Build the <span style="color:#c77dff;">QuantizeConfig</span> for SVDQuant, and call <span style="color:#c77dff;">cache_dit.quantize(...)</span> to apply SVDQuant W4A4 quantization to the model. We have to wait some time for the quantization process to finish, as SVDQuant will perform SVD decomposition for each linear layer and compute the quantization parameters based on the collected quantization statistics. The quantized model will be saved to disk in the specified directory.
-
-```python
-# 3. Build the QuantizeConfig for SVDQuant, and call `cache_dit.quantize(...)`.
-quant_config = QuantizeConfig(
-  quant_type="svdq_int4_r32", # _r{rank}, e.g., r16, r32, r64, r128, etc.
-  calibrate_fn=calibrate_fn,
-  serialize_to="./FLUX.2-klein-4B-svdq/",
-  svdq_kwargs={"calibrate_precision": "low"},  # default, optional: low | medium | high
-)
-pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
-```
-
 <span style="color:green;">calibrate_precision</span> now defaults to <span style="color:green;">low</span>, which uses randomized **torch.svd_lowrank** and keeps the calibration math in float32. **medium** and **high** remain available as opt-in debugging or accuracy-investigation modes. On a real FLUX.2-klein-4B PTQ run (**rank=32**, 8 calibration prompts, **1024x1024**), the quantized-model behavior was almost the same across all three modes; the practical difference was mostly PTQ cost. The **speedup** column below refers to quantization-time speedup relative to **high**. 
 
 | calibrate_precision | low-rank route | quantization_s | speedup | PSNR |
 | :---: | :---: | :---: | :---: | :---: |
-| low | <span style="color:green;">torch.svd_lowrank</span> with float32 | 20.2258 | <span style="color:green;">18.02x</span> | ~same, 29.2528 |
-| medium | full <span style="color:green;">torch.linalg.svd</span> with float32 | 111.8944 | 3.26x | ~same, 29.2454 |
-| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 364.4877 | 1.00x | ~same, 29.1880 |
+| low | torch.<span style="color:green;">svd_lowrank</span> w/ float32 | 20.2258 | <span style="color:green;">18.02x</span> | 29.2528 |
+| medium | full torch.linalg.<span style="color:green;">svd</span> w/ float32 | 111.8944 | 3.26x | 29.2454 |
+| high | float64 full SVD, CUDA <span style="color:green;">gesvd</span> | 364.4877 | 1.00x | 29.1880 |
 
 In practice the PSNR values are almost the same, so <span style="color:green;">low</span> is the recommended production default. It keeps the best PTQ throughput while preserving the same loaded-model behavior seen from medium and high.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "cache_dit"
 dynamic = ["version"]
 requires-python = ">=3.10"
 authors = [{name = "DefTruth, vipshop.com, etc."}]
-description = "Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers."
+description = "Cache-DiT: A PyTorch-native Inference Engine with Cache, Parallelism and Quantization for Diffusion Transformers."
 maintainers = [{name="DefTruth, vipshop.com, etc"}] 
 readme = "README.md" 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "cache_dit"
 dynamic = ["version"]
 requires-python = ">=3.10"
 authors = [{name = "DefTruth, vipshop.com, etc."}]
-description = "Cache-DiT: A PyTorch-native Inference Engine with Hybrid Cache Acceleration and Massive Parallelism for DiTs."
+description = "Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers."
 maintainers = [{name="DefTruth, vipshop.com, etc"}] 
 readme = "README.md" 
 

--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,7 @@ EXT_MODULES, CMDCLASS = _get_svdquant_extension()
 setup(
   name=PACKAGE_NAME,
   description=
-  "Cache-DiT: Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.",
+  "Cache-DiT: Cache-DiT: A PyTorch-native Inference Engine with Cache, Parallelism and Quantization for Diffusion Transformers.",
   author="DefTruth, vipshop.com",
   use_scm_version={
     "write_to": path.join("src", "cache_dit", "_version.py"),

--- a/setup.py
+++ b/setup.py
@@ -316,7 +316,7 @@ EXT_MODULES, CMDCLASS = _get_svdquant_extension()
 setup(
   name=PACKAGE_NAME,
   description=
-  "Cache-DiT: A PyTorch-native Inference Engine with Hybrid Cache Acceleration and Massive Parallelism for DiTs.",
+  "Cache-DiT: Cache-DiT: A PyTorch-native inference engine with Cache, Parallelism and Quantization for Diffusion Transformers.",
   author="DefTruth, vipshop.com",
   use_scm_version={
     "write_to": path.join("src", "cache_dit", "_version.py"),

--- a/src/cache_dit/kernels/cuda/_svdquant.py
+++ b/src/cache_dit/kernels/cuda/_svdquant.py
@@ -154,18 +154,34 @@ def _infer_svdq_output_dtype(
   return None
 
 
-def _normalize_svdq_v2_stage(stage: int | None) -> int:
-  """Normalize and validate the runtime stage for `svdq_gemm_w4a4_v2`.
+def _normalize_svdq_runtime_stage(stage: int | None, op_name: str) -> int:
+  """Normalize and validate the runtime stage for an SVDQ kernel wrapper.
 
   :param stage: Optional requested pipeline stage count.
+  :param op_name: Public operator name used in validation errors.
   :returns: A validated stage count.
   :raises ValueError: If the requested stage is outside the compiled range.
   """
 
   normalized_stage = 1 if stage is None else int(stage)
   if normalized_stage not in (1, 2, 3):
-    raise ValueError(f"svdq_gemm_w4a4_v2 stage must be one of 1, 2, or 3, got {normalized_stage}.")
+    raise ValueError(f"{op_name} stage must be one of 1, 2, or 3, got {normalized_stage}.")
   return normalized_stage
+
+
+def _normalize_svdq_v2_stage(stage: int | None) -> int:
+  """Normalize and validate the runtime stage for `svdq_gemm_w4a4_v2`.
+
+  Ada-class GPUs keep the plain v2 kernel register-bound, so the public API defaults to `stage=1` to
+  preserve better occupancy. Higher stage counts are still accepted for explicit profiling or future
+  experiments.
+
+  :param stage: Optional requested pipeline stage count.
+  :returns: A validated stage count.
+  :raises ValueError: If the requested stage is outside the compiled range.
+  """
+
+  return _normalize_svdq_runtime_stage(stage, "svdq_gemm_w4a4_v2")
 
 
 def _normalize_svdq_lora_scales(
@@ -385,6 +401,10 @@ def _call_svdq_gemm_w4a4_v2(
 ) -> None:
   """Call the dedicated plain-path v2 SVDQ GEMM entrypoint.
 
+  On Ada-class GPUs this plain path is register-bound, and `stage=1` is the
+  preferred runtime default because it keeps occupancy higher than deeper
+  pipeline settings on the hot shapes.
+
   :param act: Packed activation tensor `[M, K / 2]`.
   :param wgt: Packed quantized weight tensor `[N, K / 2]`.
   :param out: Dense output buffer `[M, N]`.
@@ -430,6 +450,7 @@ __all__ = [
   "_encode_svdq_output_dtype",
   "_get_required_utils_module",
   "_infer_svdq_output_dtype",
+  "_normalize_svdq_runtime_stage",
   "_normalize_svdq_v2_stage",
   "_normalize_svdq_lora_scales",
   "svdq_get_load_error",

--- a/src/cache_dit/kernels/ops.py
+++ b/src/cache_dit/kernels/ops.py
@@ -486,7 +486,9 @@ def svdq_gemm_w4a4_v2(
   :param act_unsigned: Whether INT4 activations are stored as unsigned values.
   :param output_dtype: Optional dtype for the allocated dense output.
   :param stage: Runtime pipeline stage count used to dispatch among the compiled v2 kernels.
-    Defaults to `1`.
+    Defaults to `1`. On Ada-class GPUs the plain v2 kernel is register-bound, so
+    `stage=1` is the preferred default because it keeps occupancy higher than
+    deeper pipeline settings on the hot shapes.
 
   :returns: A newly allocated dense output tensor `[M, N]`.
   """

--- a/src/cache_dit/quantization/svdquant/linear.py
+++ b/src/cache_dit/quantization/svdquant/linear.py
@@ -238,7 +238,10 @@ class SVDQW4A4Linear(nn.Module):
       gemm_kwargs["lora_act_in"] = lora_act
       gemm_kwargs["lora_up"] = self.proj_up
 
-    gemm_op = svdq_gemm_w4a4_v2 if self.runtime_kernel == "v2" else svdq_gemm_w4a4
+    if self.runtime_kernel == "v2":
+      gemm_op = svdq_gemm_w4a4_v2
+    else:
+      gemm_op = svdq_gemm_w4a4
     result = gemm_op(**gemm_kwargs)
     if output is not None:
       output.copy_(result)

--- a/tests/quantization/_svdq_test_utils.py
+++ b/tests/quantization/_svdq_test_utils.py
@@ -311,7 +311,10 @@ def run_svdq_operator_from_state_dict(
   if proj_down.shape[1] > 0:
     gemm_kwargs["lora_act_in"] = lora_activations
     gemm_kwargs["lora_up"] = state_dict["proj_up"]
-  gemm_op = svdq_gemm_w4a4_v2 if operator_version == "v2" else svdq_gemm_w4a4
+  if operator_version == "v2":
+    gemm_op = svdq_gemm_w4a4_v2
+  else:
+    gemm_op = svdq_gemm_w4a4
   output = gemm_op(**gemm_kwargs)
   return output[:activations.shape[0]]
 

--- a/tests/quantization/test_svdquant_imports.py
+++ b/tests/quantization/test_svdquant_imports.py
@@ -54,7 +54,7 @@ def test_svdq_w4a4_linear_rejects_unknown_runtime_kernel() -> None:
       out_features=64,
       rank=32,
       precision="int4",
-      runtime_kernel="v3",
+      runtime_kernel="v4",
     )
   except ValueError as exc:
     assert "runtime_kernel" in str(exc)


### PR DESCRIPTION
完整的 `v1/v2` bench 已经跑完了，结果在 GPU 7、`cdit` 环境下生成。当前这套 bench harness 的完整维度覆盖是：`M ∈ {256, 1024, 4096, 8192}`，`N = K = 4096`，`rank ∈ {32, 128}`，`block_m ∈ {64, 128, 256}`，`stage ∈ {default(=1), 1, 2, 3}`，总共 `96` 行数据。完整明细我已经落盘到 Markdown 汇总、CSV、JSON。

整体结论很直接：`v2` 全部 `96` 行都和 `v1` 精确一致，`exact_match_all = True`。平均加速比是 `1.088798x`，最小 `0.859428x`，最大 `1.414847x`。量化开销范围是 `act_quant_ms = 0.106496 ~ 74.498047 ms`，`wgt_quant_ms = 0.083968 ~ 1.757184 ms`。另外，default path 的 `stage=1` 和显式 `stage=1` 在所有 case 上也都是精确一致。

按 `(rank, M, N, K)` 聚合后的结果如下：

| rank | M | N | K | 最优 block_m | 最优 stage | 最优 v1 ms | 最优 v2 ms | 最优 speedup | 默认 block_m | 默认 v2 ms | 默认 speedup |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 32 | 256 | 4096 | 4096 | 128 | 1 | 0.066355 | 0.046899 | 1.414847 | 128 | 0.046899 | 1.414847 |
| 32 | 1024 | 4096 | 4096 | 128 | 1 | 0.131285 | 0.102571 | 1.279950 | 128 | 0.102571 | 1.279950 |
| 32 | 4096 | 4096 | 4096 | 256 | 1 | 0.387200 | 0.379200 | 1.021097 | 256 | 0.379264 | 1.020925 |
| 32 | 8192 | 4096 | 4096 | 128 | 1 | 0.770219 | 0.712704 | 1.080699 | 128 | 0.712789 | 1.080570 |
| 128 | 256 | 4096 | 4096 | 64 | 2 | 0.071834 | 0.051533 | 1.393939 | 128 | 0.052787 | 1.360815 |
| 128 | 1024 | 4096 | 4096 | 128 | 1 | 0.141909 | 0.112299 | 1.263678 | 128 | 0.112384 | 1.262718 |
| 128 | 4096 | 4096 | 4096 | 256 | 1 | 0.419456 | 0.411392 | 1.019602 | 256 | 0.411712 | 1.018809 |
| 128 | 8192 | 4096 | 4096 | 128 | 1 | 0.832597 | 0.778923 | 1.068909 | 128 | 0.779264 | 1.068441 |

可以看到这轮完整 sweep 下，`v2` 的优势主要集中在小到中等 `M`。`M=256/1024` 时收益明显，最佳可到 `1.41x / 1.28x`；到了 `M=4096/8192`，收益明显收敛到大约 `1.02x ~ 1.08x`。默认配置也基本就是最优配置，只有 `rank=128, M=256` 这一组里，最佳点落在 `block_m=64, stage=2`，但默认 `block_m=128, stage=1` 也还有 `1.360815x`，和最优点差距不大。