### PR TITLE
svdq: support converter cli for dq workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ CLAUDE.local.md
 /.tmp/
 .vscode
 tools
+.claude

--- a/docs/user_guide/QUANTIZATION.md
+++ b/docs/user_guide/QUANTIZATION.md
@@ -701,6 +701,110 @@ At the backend-config level, this means DQ currently supports <span style="color
 
 The CLI also exposes <span style="color:#c77dff;">--svdq-calibrate-precision</span> (alias <span style="color:#c77dff;">--svdq-calib</span>) for the SVDQ decomposition math. For DQ, the default remains <span style="color:#c77dff;">low</span> to preserve the shipped fast path, but users can now explicitly select <span style="color:#c77dff;">medium</span> or <span style="color:#c77dff;">high</span> when they want a different accuracy / quantization-time trade-off. The few-shot CLI also exposes <span style="color:#c77dff;">--svdq-few-shot-steps</span>, <span style="color:#c77dff;">--svdq-few-shot-relax-factor</span>, <span style="color:#c77dff;">--svdq-few-shot-relax-top-ratio</span>, <span style="color:#c77dff;">--svdq-few-shot-relax-strategy</span>, and <span style="color:#c77dff;">--svdq-few-shot-compile</span>. In the shared helper flow, top-level <span style="color:#c77dff;">--compile</span> is treated as a compatibility alias for few-shot runs, while <span style="color:#c77dff;">--svdq-few-shot-compile</span> is the precise switch that means "compile only after runtime quantization completes". The parser also accepts <span style="color:#c77dff;">top_q4</span> as an alias of <span style="color:#c77dff;">top</span>, but <span style="color:#c77dff;">fixed</span>, <span style="color:#c77dff;">top</span>, <span style="color:#c77dff;">auto</span>, <span style="color:#c77dff;">stable_auto</span>, <span style="color:#c77dff;">power</span>, <span style="color:#c77dff;">log</span>, and <span style="color:#c77dff;">rank</span> are the canonical strategy names.
 
+## SVDQ Converter CLI
+
+Cache-DiT ships a standalone converter CLI that loads a pretrained diffusion pipeline and converts it to an SVDQ W4A4 quantized format in a single step. The converter currently supports <span style="color:green;">SVDQ dynamic quantization (`_dq`)</span> only — it does not require a calibration dataset or a calibration callback.
+
+The converter is available via the <span style="color:#c77dff;">cache-dit-convert</span> console script or as a runnable module:
+
+```bash
+# Console script (installed with cache-dit):
+cache-dit-convert --model-path /path/to/FLUX.1-dev \
+  --save-dir ./FLUX.1-dev-svdq \
+  --quant-type svdq-int4-r128-dq
+
+# Equivalent Python module invocation:
+python3 -m cache_dit.quantization.converter \
+  --model-path /path/to/FLUX.1-dev \
+  --save-dir ./FLUX.1-dev-svdq \
+  --quant-type svdq-int4-r128-dq
+```
+
+### CLI reference
+
+| Argument | Required | Default | Description |
+| :--- | :---: | :---: | :--- |
+| `--model-path` | yes | — | Path to the pretrained diffusion model directory (e.g. `/path/to/FLUX.1-dev`). |
+| `--save-dir` | yes | — | Directory where the quantized checkpoint (`{quant_type}.safetensors`) and `quant_config.json` are saved. |
+| `--quant-type` | yes | — | SVDQ quant type, accepting both hyphen (`svdq-int4-r128-dq`) and underscore (`svdq_int4_r128_dq`) forms. Currently only `_dq` types are supported. |
+| `--torch-dtype` | no | `bfloat16` | Torch dtype used when loading the float pipeline. One of: `float16`, `bfloat16`, `float32`. |
+| `--device` | no | `cuda` | Device to run quantization on. |
+| `--svdq-smooth-strategy` | no | `identity` | SVDQ DQ smooth strategy. One of: `identity`, `weight`, `weight_inv`, `few_shot`. See the [SVDQuant DQ section](#svdquant-w4a4-dq) for details. |
+| `--svdq-calibrate-precision` | no | `low` | Precision plan for SVDQ decomposition math. One of: `low`, `medium`, `high`. |
+| `--svdq-runtime-kernel` | no | `v1` | Packed runtime GEMM kernel used by `SVDQW4A4Linear`. One of: `v1`, `v2`. |
+| `--verbose` | no | `false` | Print detailed quantization information including per-layer skip reasons. |
+
+### Usage examples
+
+**Basic conversion — identity smooth (zero calibration):**
+
+```bash
+cache-dit-convert \
+  --model-path black-forest-labs/FLUX.2-klein-4B \
+  --save-dir ./FLUX.2-klein-4B-svdq \
+  --quant-type svdq-int4-r128-dq
+```
+
+Output:
+
+```
+Loading pipeline from black-forest-labs/FLUX.2-klein-4B ...
+Pipeline loaded: Flux2KleinPipeline
+Transformer memory before quantize: 7.22 GiB
+Quantizing transformer (svdq_int4_r128_dq) and saving to ./FLUX.2-klein-4B-svdq ...
+Transformer memory after quantize: 2.28 GiB (3.2x reduction)
+Quantized checkpoint saved to ./FLUX.2-klein-4B-svdq/svdq_int4_r128_dq.safetensors
+Quant config saved to ./FLUX.2-klein-4B-svdq/quant_config.json
+Conversion complete. Load the quantized model with:
+  cache_dit.load(transformer, './FLUX.2-klein-4B-svdq/')
+```
+
+**Experimental weight-only smooth strategy:**
+
+```bash
+cache-dit-convert \
+  --model-path black-forest-labs/FLUX.2-klein-4B \
+  --save-dir ./FLUX.2-klein-4B-svdq \
+  --quant-type svdq-int4-r256-dq \
+  --svdq-smooth-strategy weight \
+  --svdq-calibrate-precision medium
+```
+
+**With v2 runtime kernel and verbose logging:**
+
+```bash
+cache-dit-convert \
+  --model-path /path/to/FLUX.1-dev \
+  --save-dir ./FLUX.1-dev-svdq \
+  --quant-type svdq-int4-r64-dq \
+  --svdq-runtime-kernel v2 \
+  --verbose
+```
+
+### Loading the converted model
+
+After conversion, the <span style="color:green;">save-dir</span> directory contains `{quant_type}.safetensors` and `quant_config.json`. Load the quantized model for inference with `cache_dit.load`:
+
+```python
+import torch
+import cache_dit
+from diffusers import Flux2KleinPipeline
+
+pipe = Flux2KleinPipeline.from_pretrained(...)
+pipe.transformer = cache_dit.load(pipe.transformer, "./FLUX.2-klein-4B-svdq/")
+pipe.to("cuda")
+image = pipe("A cat sitting on the beach.", height=1024, width=1024).images[0]
+```
+
+You can also pass the safetensors path directly:
+
+```python
+pipe.transformer = cache_dit.load(
+    pipe.transformer,
+    "./FLUX.2-klein-4B-svdq/svdq_int4_r128_dq.safetensors"
+)
+```
+
 ## SVDQ Runtime Kernel
 
 Cache-DiT's SVDQuant support also includes a high-performance W4A4 GEMM kernel for efficient runtime execution of SVDQ-quantized models. This kernel is optimized for Ada and Ampere architectures and can provide slightly better performance compared to existing INT4 GEMM kernels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ GitHub = "https://github.com/vipshop/cache-dit"
 
 cache-dit-metrics = "cache_dit.metrics:main" # metric entrypoint
 cache-dit-generate = "cache_dit.generate:entrypoint" # example entrypoint
+cache-dit-convert = "cache_dit.quantization.converter:main" # model conversion entrypoint
 
 [build-system]
 

--- a/src/cache_dit/quantization/config.py
+++ b/src/cache_dit/quantization/config.py
@@ -439,8 +439,6 @@ class QuantizeConfig:
       if self.is_svdq_dq():
         if self.calibrate_fn is not None:
           raise ValueError("calibrate_fn is not supported for SVDQuant dynamic quantization.")
-        if self.serialize_to is not None:
-          raise ValueError("serialize_to is not supported for SVDQuant dynamic quantization.")
         if isinstance(raw_svdq_kwargs, dict) and "smooth_strategy" in raw_svdq_kwargs:
           requested_smooth_strategy = str(raw_svdq_kwargs["smooth_strategy"]).lower()
           if requested_smooth_strategy not in {"identity", "weight", "weight_inv", "few_shot"}:
@@ -458,12 +456,12 @@ class QuantizeConfig:
           raise ValueError("calibrate_fn must be set for SVDQuant PTQ workflow.")
         if self.serialize_to is None:
           raise ValueError("serialize_to must be set for SVDQuant PTQ workflow.")
+      if self.serialize_to is not None:
         normalized_filename = f"{self.quant_type}.safetensors"
         if self.serialize_to.endswith(".safetensors"):
           if os.path.basename(self.serialize_to) != normalized_filename:
-            raise ValueError(
-              "serialize_to must be a directory path for SVDQuant PTQ, or an already "
-              f"normalized file path ending with {normalized_filename!r}.")
+            raise ValueError("serialize_to must be a directory path for SVDQuant, or an already "
+                             f"normalized file path ending with {normalized_filename!r}.")
           serialize_dir = os.path.dirname(self.serialize_to)
           if not serialize_dir:
             raise ValueError("serialize_to must include a parent directory.")

--- a/src/cache_dit/quantization/converter.py
+++ b/src/cache_dit/quantization/converter.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import torch
 
 from ..logger import init_logger
 
@@ -89,13 +90,21 @@ def _get_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _resolve_torch_dtype(torch_dtype: str):
-  import torch
 
   return {
     "float16": torch.float16,
     "bfloat16": torch.bfloat16,
     "float32": torch.float32,
   }[torch_dtype]
+
+
+def _module_memory_gib(module) -> float:
+  """Return the total memory of all parameters in *module*, in GiB."""
+
+  total_bytes = 0
+  for param in module.parameters():
+    total_bytes += param.numel() * param.element_size()
+  return total_bytes / (1024 * 1024 * 1024)
 
 
 def entrypoint(argv: list[str] | None = None) -> None:
@@ -110,7 +119,6 @@ def entrypoint(argv: list[str] | None = None) -> None:
     )
     sys.exit(1)
 
-  import torch
   from diffusers import DiffusionPipeline
 
   from cache_dit.quantization import QuantizeConfig
@@ -145,8 +153,13 @@ def entrypoint(argv: list[str] | None = None) -> None:
   )
 
   # --- Quantize and serialize ---
+  memory_before_gib = _module_memory_gib(pipe.transformer)
+  logger.info("Transformer memory before quantize: %.2f GiB", memory_before_gib)
   logger.info("Quantizing transformer (%s) and saving to %s ...", quant_type, save_dir)
   pipe.transformer = quantize(pipe.transformer, config)
+  memory_after_gib = _module_memory_gib(pipe.transformer)
+  logger.info("Transformer memory after quantize: %.2f GiB (%.1fx reduction)", memory_after_gib,
+              memory_before_gib / memory_after_gib)
 
   expected_safetensors = os.path.join(save_dir, f"{quant_type}.safetensors")
   expected_config = os.path.join(save_dir, "quant_config.json")

--- a/src/cache_dit/quantization/converter.py
+++ b/src/cache_dit/quantization/converter.py
@@ -1,0 +1,174 @@
+"""Convert a diffusion model to SVDQ int4 quantized format.
+
+Usage::
+
+    python3 -m cache_dit.quantization.converter \\
+        --model-path /path/to/FLUX.1-dev \\
+        --save-dir ./FLUX.1-dev-svdq \\
+        --quant-type svdq-int4-r128-dq
+
+Only SVDQ dynamic quantization (``_dq`` quant types) is currently supported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from ..logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _get_args(argv: list[str] | None = None) -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+    description="Convert a diffusion model to SVDQ int4 quantized format.",
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+  )
+  parser.add_argument(
+    "--model-path",
+    type=str,
+    required=True,
+    help="Path to the pretrained diffusion model directory (e.g. /path/to/FLUX.1-dev).",
+  )
+  parser.add_argument(
+    "--save-dir",
+    type=str,
+    required=True,
+    help="Directory where the quantized checkpoint and config will be saved.",
+  )
+  parser.add_argument(
+    "--quant-type",
+    type=str,
+    required=True,
+    help="SVDQ quant type, e.g. 'svdq-int4-r128-dq' or 'svdq_int4_r128_dq'. "
+    "Currently only DQ types (ending with '_dq') are supported.",
+  )
+  parser.add_argument(
+    "--torch-dtype",
+    type=str,
+    default="bfloat16",
+    choices=("float16", "bfloat16", "float32"),
+    help="Torch dtype used when loading the float pipeline.",
+  )
+  parser.add_argument(
+    "--device",
+    type=str,
+    default="cuda",
+    help="Device to run quantization on.",
+  )
+  parser.add_argument(
+    "--svdq-smooth-strategy",
+    type=str,
+    default=None,
+    choices=("identity", "weight", "weight_inv", "few_shot"),
+    help="SVDQ DQ smooth strategy. Defaults to 'identity' when not set.",
+  )
+  parser.add_argument(
+    "--svdq-calibrate-precision",
+    type=str,
+    default="low",
+    choices=("low", "medium", "high"),
+    help="Precision plan for SVDQ calibration math and low-rank decomposition.",
+  )
+  parser.add_argument(
+    "--svdq-runtime-kernel",
+    type=str,
+    default="v1",
+    choices=("v1", "v2"),
+    help="Packed runtime GEMM kernel used by SVDQW4A4Linear.",
+  )
+  parser.add_argument(
+    "--verbose",
+    action="store_true",
+    default=False,
+    help="Print detailed quantization information.",
+  )
+  return parser.parse_args(argv)
+
+
+def _resolve_torch_dtype(torch_dtype: str):
+  import torch
+
+  return {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+  }[torch_dtype]
+
+
+def entrypoint(argv: list[str] | None = None) -> None:
+  args = _get_args(argv)
+
+  quant_type = args.quant_type.replace("-", "_").lower()
+  if not quant_type.endswith("_dq"):
+    logger.error(
+      "Currently only SVDQ dynamic quantization (quant types ending with '_dq') is supported. "
+      "Got %r.",
+      args.quant_type,
+    )
+    sys.exit(1)
+
+  import torch
+  from diffusers import DiffusionPipeline
+
+  from cache_dit.quantization import QuantizeConfig
+  from cache_dit.quantization import quantize
+
+  torch_dtype = _resolve_torch_dtype(args.torch_dtype)
+  device = torch.device(args.device)
+
+  # --- Load the pipeline ---
+  logger.info("Loading pipeline from %s ...", args.model_path)
+  pipe = DiffusionPipeline.from_pretrained(
+    args.model_path,
+    torch_dtype=torch_dtype,
+  )
+  pipe.to(device)
+  logger.info("Pipeline loaded: %s", type(pipe).__name__)
+
+  # --- Build quantization config ---
+  svdq_kwargs = {
+    "calibrate_precision": args.svdq_calibrate_precision,
+    "runtime_kernel": args.svdq_runtime_kernel,
+  }
+  if args.svdq_smooth_strategy is not None:
+    svdq_kwargs["smooth_strategy"] = args.svdq_smooth_strategy
+
+  save_dir = os.path.abspath(args.save_dir)
+  config = QuantizeConfig(
+    quant_type=quant_type,
+    serialize_to=save_dir,
+    svdq_kwargs=svdq_kwargs if svdq_kwargs else None,
+    verbose=args.verbose,
+  )
+
+  # --- Quantize and serialize ---
+  logger.info("Quantizing transformer (%s) and saving to %s ...", quant_type, save_dir)
+  pipe.transformer = quantize(pipe.transformer, config)
+
+  expected_safetensors = os.path.join(save_dir, f"{quant_type}.safetensors")
+  expected_config = os.path.join(save_dir, "quant_config.json")
+  logger.info("Quantized checkpoint saved to %s", expected_safetensors)
+  logger.info("Quant config saved to %s", expected_config)
+
+  # --- Verify the artifacts exist ---
+  if not os.path.isfile(expected_safetensors):
+    logger.error("Expected safetensors file not found: %s", expected_safetensors)
+    sys.exit(1)
+  if not os.path.isfile(expected_config):
+    logger.error("Expected quant_config.json not found: %s", expected_config)
+    sys.exit(1)
+
+  logger.info("Conversion complete. Load the quantized model with:")
+  logger.info("  cache_dit.load(transformer, %r)", save_dir)
+  logger.info("  cache_dit.load(transformer, %r)", expected_safetensors)
+
+
+def main() -> None:
+  entrypoint()
+
+
+if __name__ == "__main__":
+  main()

--- a/src/cache_dit/quantization/dispatch.py
+++ b/src/cache_dit/quantization/dispatch.py
@@ -74,8 +74,6 @@ def load(
   """
 
   if isinstance(quantize_config_or_path, QuantizeConfig):
-    if quantize_config_or_path.is_svdq_dq():
-      raise ValueError("SVDQ dynamic quantization does not support load().")
     backend = quantize_config_or_path.backend
   elif isinstance(quantize_config_or_path, str):
     backend = QuantizeBackend.CACHE_DIT

--- a/src/cache_dit/quantization/svdquant/ptq.py
+++ b/src/cache_dit/quantization/svdquant/ptq.py
@@ -738,6 +738,7 @@ class SVDQFewShotRuntimeController:
 
   context: SVDQPTQContext
   quantize_device: torch.device
+  serialize_to: str | None = None
   completed_forwards: int = 0
   collect_current_forward: bool = False
   activation_spans: dict[str, torch.Tensor] = dataclasses.field(default_factory=dict)
@@ -902,9 +903,32 @@ class SVDQFewShotRuntimeController:
       quantized_layer_names=quantized_layer_names,
       exclude_layers=self.context.exclude_layers,
       svdq_kwargs=self.context.svdq_kwargs,
-      checkpoint_path=None,
+      checkpoint_path=self.serialize_to,
       quantize_config=self.context.quantize_config,
     )
+    if self.serialize_to is not None:
+      _save_quantized_module(
+        module,
+        serialize_to=self.serialize_to,
+        quant_type=self.context.quantize_config.quant_type,
+        rank=self.context.rank,
+        quantized_layer_names=quantized_layer_names,
+        svdq_kwargs=self.context.svdq_kwargs,
+      )
+      _save_quant_config_snapshot(
+        _build_quant_config_snapshot(
+          checkpoint_path=self.serialize_to,
+          quant_type=self.context.quantize_config.quant_type,
+          rank=self.context.rank,
+          exclude_layers=self.context.exclude_layers,
+          regional_quantize=self.context.regional_quantize,
+          repeated_blocks=self.context.repeated_blocks,
+          verbose=self.context.verbose,
+          svdq_kwargs=self.context.svdq_kwargs,
+          backend=self.context.quantize_config.backend,
+        ),
+        checkpoint_path=self.serialize_to,
+      )
     _maybe_enable_layerwise_runtime_offload(
       module,
       quantized_layer_names=quantized_layer_names,
@@ -916,7 +940,7 @@ class SVDQFewShotRuntimeController:
     _log_quantize_summary(
       self.context,
       quantized_layer_names=quantized_layer_names,
-      serialize_to=None,
+      serialize_to=self.serialize_to,
       observed_layer_names=observed_layer_names,
     )
     _run_post_quantize_callbacks(
@@ -1449,7 +1473,11 @@ def quantize_svdq_dq(module: nn.Module, quantize_config: QuantizeConfig) -> nn.M
   quantize_device = _resolve_svdq_quantize_device(module, context.svdq_kwargs)
 
   if quantize_config.is_svdq_dq_few_shot():
-    controller = SVDQFewShotRuntimeController(context=context, quantize_device=quantize_device)
+    controller = SVDQFewShotRuntimeController(
+      context=context,
+      quantize_device=quantize_device,
+      serialize_to=quantize_config.serialize_to,
+    )
     return controller.arm()
 
   was_training = module.training
@@ -1474,13 +1502,36 @@ def quantize_svdq_dq(module: nn.Module, quantize_config: QuantizeConfig) -> nn.M
     quantized_layer_names=quantized_layer_names,
     exclude_layers=context.exclude_layers,
     svdq_kwargs=context.svdq_kwargs,
-    checkpoint_path=None,
+    checkpoint_path=quantize_config.serialize_to,
     quantize_config=quantize_config,
   )
+  if quantize_config.serialize_to is not None:
+    _save_quantized_module(
+      module,
+      serialize_to=quantize_config.serialize_to,
+      quant_type=quantize_config.quant_type,
+      rank=context.rank,
+      quantized_layer_names=quantized_layer_names,
+      svdq_kwargs=context.svdq_kwargs,
+    )
+    _save_quant_config_snapshot(
+      _build_quant_config_snapshot(
+        checkpoint_path=quantize_config.serialize_to,
+        quant_type=quantize_config.quant_type,
+        rank=context.rank,
+        exclude_layers=context.exclude_layers,
+        regional_quantize=context.regional_quantize,
+        repeated_blocks=context.repeated_blocks,
+        verbose=context.verbose,
+        svdq_kwargs=context.svdq_kwargs,
+        backend=quantize_config.backend,
+      ),
+      checkpoint_path=quantize_config.serialize_to,
+    )
   _log_quantize_summary(
     context,
     quantized_layer_names=quantized_layer_names,
-    serialize_to=None,
+    serialize_to=quantize_config.serialize_to,
     observed_layer_names=None,
   )
   _maybe_collect_svdq_garbage(quantize_device)
@@ -1491,7 +1542,7 @@ def load_svdq(
   module: nn.Module,
   quantize_config_or_path: QuantizeConfig | str,
 ) -> nn.Module:
-  """Load a serialized SVDQ PTQ checkpoint into a float module in place.
+  """Load a serialized SVDQ checkpoint into a float module in place.
 
   :param module: Root module containing float `nn.Linear` layers that match the
   serialized checkpoint layout.

--- a/tests/quantization/test_svdquant_dq.py
+++ b/tests/quantization/test_svdquant_dq.py
@@ -440,17 +440,11 @@ def test_svdq_dq_config_validation_accepts_device_strategy_kwargs() -> None:
   assert config.get_svdq_kwargs()["defer_move_to_execution_device"] is True
 
 
-def test_svdq_dq_config_validation_rejects_ptq_only_fields_and_load(tmp_path: Path) -> None:
+def test_svdq_dq_config_validation_rejects_ptq_only_fields(tmp_path: Path) -> None:
   with pytest.raises(ValueError, match="calibrate_fn"):
     QuantizeConfig(
       quant_type="svdq_int4_r32_dq",
       calibrate_fn=lambda **_: None,
-    )
-
-  with pytest.raises(ValueError, match="serialize_to"):
-    QuantizeConfig(
-      quant_type="svdq_int4_r32_dq",
-      serialize_to=str(tmp_path / "svdq_int4_r32_dq.safetensors"),
     )
 
   with pytest.raises(ValueError, match="smooth_strategy"):
@@ -459,12 +453,149 @@ def test_svdq_dq_config_validation_rejects_ptq_only_fields_and_load(tmp_path: Pa
       svdq_kwargs={"smooth_strategy": "activation"},
     )
 
-  config = QuantizeConfig(quant_type="svdq_int4_r32_dq")
-  with pytest.raises(ValueError, match="does not support load"):
-    cache_dit.load(
-      nn.Linear(128, 128, device="cuda", dtype=runtime_dtype()),
-      config,
-    )
+
+def test_svdq_dq_config_validation_accepts_serialize_to(tmp_path: Path) -> None:
+  config = QuantizeConfig(
+    quant_type="svdq_int4_r32_dq",
+    serialize_to=str(tmp_path / "checkpoints"),
+  )
+  expected = str(tmp_path / "checkpoints" / "svdq_int4_r32_dq.safetensors")
+  assert config.serialize_to == expected
+  assert os.path.isdir(tmp_path / "checkpoints")
+
+
+def test_svdq_dq_quantize_and_serialize_toy_model(tmp_path: Path) -> None:
+  dtype = runtime_dtype()
+  float_model = make_toy_model(
+    embed_dim=128,
+    num_heads=4,
+    seed=42,
+    device="cuda",
+    dtype=dtype,
+  )
+  serialize_to = str(tmp_path / "checkpoints")
+  config = _make_dq_config(rank=32, serialize_to=serialize_to)
+
+  quantized_model = cache_dit.quantize(float_model, config)
+
+  expected_safetensors = os.path.join(serialize_to, "svdq_int4_r32_dq.safetensors")
+  expected_config = os.path.join(serialize_to, "quant_config.json")
+  assert os.path.isfile(expected_safetensors)
+  assert os.path.isfile(expected_config)
+  assert getattr(quantized_model, "_svdq_checkpoint_path", None) == expected_safetensors
+
+
+def test_svdq_dq_load_roundtrip_restores_quantized_outputs(tmp_path: Path) -> None:
+  dtype = runtime_dtype()
+  float_model = make_toy_model(
+    embed_dim=128,
+    num_heads=4,
+    seed=43,
+    device="cuda",
+    dtype=dtype,
+  )
+  eval_inputs = make_token_batch(
+    batch_size=2,
+    seq_len=12,
+    width=128,
+    seed=57,
+    device="cuda",
+    dtype=dtype,
+  )
+
+  serialize_to = str(tmp_path / "checkpoints")
+  config = _make_dq_config(rank=32, serialize_to=serialize_to)
+
+  with torch.inference_mode():
+    _ = float_model(eval_inputs)
+
+  quantized_model = cache_dit.quantize(copy.deepcopy(float_model), config)
+  with torch.inference_mode():
+    quantized_output = quantized_model(eval_inputs)
+
+  # Load from the serialized checkpoint into a fresh float model
+  loaded_model = cache_dit.load(
+    copy.deepcopy(float_model),
+    config,
+  )
+  with torch.inference_mode():
+    loaded_output = loaded_model(eval_inputs)
+
+  torch.testing.assert_close(loaded_output, quantized_output, rtol=1e-4, atol=1e-4)
+
+  # Also verify load works with the checkpoint path directly
+  loaded_model2 = cache_dit.load(
+    copy.deepcopy(float_model),
+    config.serialize_to,
+  )
+  with torch.inference_mode():
+    loaded_output2 = loaded_model2(eval_inputs)
+  torch.testing.assert_close(loaded_output2, quantized_output, rtol=1e-4, atol=1e-4)
+
+
+def test_svdq_dq_few_shot_quantize_and_serialize(tmp_path: Path) -> None:
+  dtype = runtime_dtype()
+  float_model = make_toy_model(
+    embed_dim=128,
+    num_heads=4,
+    seed=44,
+    device="cuda",
+    dtype=dtype,
+  )
+  eval_inputs = make_token_batch(
+    batch_size=2,
+    seq_len=12,
+    width=128,
+    seed=58,
+    device="cuda",
+    dtype=dtype,
+  )
+
+  serialize_to = str(tmp_path / "checkpoints")
+  few_shot_steps = 2
+  config = _make_dq_config(
+    rank=32,
+    serialize_to=serialize_to,
+    svdq_kwargs={
+      "smooth_strategy": "few_shot",
+      "few_shot_steps": few_shot_steps,
+    },
+  )
+
+  # Arm the model with few-shot DQ (no quantization yet)
+  armed_model = cache_dit.quantize(float_model, config)
+  assert getattr(armed_model, "_svdq_pending_quantization",
+                 False), ("Expected pending quantization after few-shot arm.")
+
+  # The safetensors file should not exist yet — quantization hasn't materialized
+  expected_safetensors = os.path.join(serialize_to, "svdq_int4_r32_dq.safetensors")
+  assert not os.path.isfile(expected_safetensors), (
+    "Serialized checkpoint must not be written before few-shot forwards complete.")
+
+  # Run enough forwards to trigger deferred materialization
+  with torch.inference_mode():
+    for _ in range(few_shot_steps):
+      _ = armed_model(eval_inputs)
+
+  # After enough forwards, the safetensors and quant_config.json should exist
+  expected_config = os.path.join(serialize_to, "quant_config.json")
+  assert os.path.isfile(expected_safetensors)
+  assert os.path.isfile(expected_config)
+  assert getattr(armed_model, "_svdq_checkpoint_path", None) == expected_safetensors
+
+  # Load from checkpoint and verify outputs
+  fresh_model = make_toy_model(
+    embed_dim=128,
+    num_heads=4,
+    seed=44,
+    device="cuda",
+    dtype=dtype,
+  )
+  loaded_model = cache_dit.load(fresh_model, config)
+  with torch.inference_mode():
+    armed_output = armed_model(eval_inputs)
+    loaded_output = loaded_model(eval_inputs)
+  torch.testing.assert_close(loaded_output, armed_output, rtol=1e-4, atol=1e-4)
 
 
 def test_svdq_dq_skips_calibrator_registration(monkeypatch) -> None:


### PR DESCRIPTION
```bash
python3 -m cache_dit.quantization.converter --model-path /workspace/dev/vipdev/hf_models/FLUX.1-dev --save-dir ./FLUX.1-dev-svdq --quant-type "svdq-int4-r128-dq"
[04-28 10:15:13] [Cache-DiT] Loading pipeline from /workspace/dev/vipdev/hf_models/FLUX.1-dev ...
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 219/219 [00:00<00:00, 9832.50it/s]
Loading weights: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 196/196 [00:00<00:00, 10298.06it/s]
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 41.22it/s]
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  9.17it/s]
[04-28 10:15:22] [Cache-DiT] Pipeline loaded: FluxPipeline
[04-28 10:15:22] [Cache-DiT] Transformer memory before quantize: 22.17 GiB
[04-28 10:15:22] [Cache-DiT] Quantizing transformer (svdq_int4_r128_dq) and saving to /workspace/dev/vipshop/cache-dit/examples/FLUX.1-dev-svdq ...
[04-28 10:15:49] [Cache-DiT] ----------------------------------------------------------------------------
[04-28 10:15:49] [Cache-DiT] SVDQuant    Region: ['FluxTransformerBlock', 'FluxSingleTransformerBlock']  |
[04-28 10:15:49] [Cache-DiT] SVDQuant      Type: svdq_int4_r128_dq                                       |
[04-28 10:15:49] [Cache-DiT] SVDQuant      Rank: 128                                                     |
[04-28 10:15:49] [Cache-DiT] Quantized   Layers: 494 / 494                                               |
[04-28 10:15:49] [Cache-DiT] Skipped     Layers: 0                                                       |
[04-28 10:15:49] [Cache-DiT] Linear      Layers: 494                                                     |
[04-28 10:15:49] [Cache-DiT] ----------------------------------------------------------------------------
[04-28 10:15:50] [Cache-DiT] Transformer memory after quantize: 7.27 GiB (3.0x reduction)
[04-28 10:15:50] [Cache-DiT] Quantized checkpoint saved to /workspace/dev/vipshop/cache-dit/examples/FLUX.1-dev-svdq/svdq_int4_r128_dq.safetensors
[04-28 10:15:50] [Cache-DiT] Quant config saved to /workspace/dev/vipshop/cache-dit/examples/FLUX.1-dev-svdq/quant_config.json
[04-28 10:15:50] [Cache-DiT] Conversion complete. Load the quantized model with:
[04-28 10:15:50] [Cache-DiT]   cache_dit.load(transformer, '/workspace/dev/vipshop/cache-dit/examples/FLUX.1-dev-svdq')
[04-28 10:15:50] [Cache-DiT]   cache_dit.load(transformer, '/workspace/dev/vipshop/cache-dit/examples/FLUX.1-dev-svdq/svdq_int4_r128_dq.safetensors')
```