### PR TITLE
ray: refactor ray wrapper impl

### DIFF
--- a/src/cache_dit/caching/cache_interface.py
+++ b/src/cache_dit/caching/cache_interface.py
@@ -23,6 +23,171 @@ logger = init_logger(__name__)
 
 
 def enable_cache(
+  pipe_or_adapter: Union[
+    DiffusionPipeline,
+    BlockAdapter,
+    torch.nn.Module,
+    ModelMixin,
+  ],
+  cache_config: Optional[Union[
+    DBCacheConfig,
+    DBPruneConfig,
+  ]] = None,
+  calibrator_config: Optional[CalibratorConfig] = None,
+  params_modifiers: Optional[Union[
+    ParamsModifier,
+    List[ParamsModifier],
+    List[List[ParamsModifier]],
+  ]] = None,
+  parallelism_config: Optional[ParallelismConfig] = None,
+  attention_backend: Optional[str] = None,
+  quantize_config: Optional[QuantizeConfig] = None,
+  **kwargs,
+) -> Union[
+    DiffusionPipeline,
+    torch.nn.Module,
+    ModelMixin,
+    BlockAdapter,
+]:
+  """Enable cache acceleration for a pipeline, adapter, or transformer module.
+
+  This is the main cache-dit entry point for wiring DBCache into a model. It can wrap a full
+  `DiffusionPipeline`, a normalized `BlockAdapter`, or a transformer module directly, and it can
+  optionally layer parallelism, attention-backend selection, and quantization on top of the cache
+  hooks.
+
+  When `parallelism_config.use_ray` is ``True`` the Ray wrapper is activated: worker actors
+  own copies of the model and the main process proxies all forward calls through
+  :class:`RayParallelEngine` or :class:`RayPipelineEngine`.  Cache hooks, native parallelism,
+  and quantization are applied inside the workers via :func:`_enable_cache_impl`.
+
+  Use `cache_config` to control the caching strategy itself. Detailed cache-policy fields such as
+  warmup behavior, residual thresholds, or step masks are documented on `DBCacheConfig` and
+  `DBPruneConfig`. Calibrator-specific options belong on `calibrator_config`, and distributed
+  execution options belong on `parallelism_config`.
+
+  :param pipe_or_adapter: Pipeline, adapter, or transformer module to accelerate.
+  :param cache_config: Cache configuration describing the runtime caching strategy. When omitted and
+    no other optimization config is provided, a default `DBCacheConfig` is created.
+  :param calibrator_config: Optional calibrator configuration used to augment the cache context.
+  :param params_modifiers: Optional per-block cache-context overrides applied after the base config
+    is loaded.
+  :param parallelism_config: Optional parallelism configuration applied after cache hooks are
+    installed.
+  :param attention_backend: Optional attention backend override for non-parallel execution.
+  :param quantize_config: Optional quantization configuration applied after cache and parallelism.
+  :param kwargs: Deprecated cache-context keyword arguments kept for backward compatibility.
+  :returns: The original object with cache-dit hooks and optional optimizations applied.
+
+  Example::
+
+    >>> import cache_dit
+    >>> from diffusers import DiffusionPipeline
+    >>> pipe = DiffusionPipeline.from_pretrained("Qwen/Qwen-Image")
+    >>> pipe = cache_dit.enable_cache(pipe)
+    >>> output = pipe(...)
+    >>> stats = cache_dit.summary(pipe)
+  """
+  ray_enabled = isinstance(parallelism_config, ParallelismConfig) and parallelism_config.use_ray
+  if ray_enabled:
+    return _enable_cache_with_ray_impl(
+      pipe_or_adapter,
+      cache_config=cache_config,
+      calibrator_config=calibrator_config,
+      params_modifiers=params_modifiers,
+      parallelism_config=parallelism_config,
+      attention_backend=attention_backend,
+      quantize_config=quantize_config,
+      **kwargs,
+    )
+  return _enable_cache_impl(
+    pipe_or_adapter,
+    cache_config=cache_config,
+    calibrator_config=calibrator_config,
+    params_modifiers=params_modifiers,
+    parallelism_config=parallelism_config,
+    attention_backend=attention_backend,
+    quantize_config=quantize_config,
+    **kwargs,
+  )
+
+
+def _enable_cache_with_ray_impl(
+  pipe_or_adapter: Union[
+    DiffusionPipeline,
+    BlockAdapter,
+    torch.nn.Module,
+    ModelMixin,
+  ],
+  cache_config: Optional[Union[
+    DBCacheConfig,
+    DBPruneConfig,
+  ]] = None,
+  calibrator_config: Optional[CalibratorConfig] = None,
+  params_modifiers: Optional[Union[
+    ParamsModifier,
+    List[ParamsModifier],
+    List[List[ParamsModifier]],
+  ]] = None,
+  parallelism_config: Optional[ParallelismConfig] = None,
+  attention_backend: Optional[str] = None,
+  quantize_config: Optional[QuantizeConfig] = None,
+  **kwargs,
+) -> Union[
+    DiffusionPipeline,
+    torch.nn.Module,
+    ModelMixin,
+    BlockAdapter,
+]:
+  """Internal: Ray-path passthrough — packages configs and delegates to Ray wrappers.
+
+  All preprocessing (deprecated params, default configs, calibrator setup,
+  attention backend resolution, parallelism tuning, quantization) is deferred to
+  :func:`_enable_cache_impl` running inside each Ray worker.
+  """
+
+  if attention_backend is not None:
+    parallelism_config.attention_backend = attention_backend
+
+  ctx = {}
+  if cache_config is not None:
+    ctx["cache_config"] = cache_config
+  if calibrator_config is not None:
+    ctx["calibrator_config"] = calibrator_config
+  if params_modifiers is not None:
+    ctx["params_modifiers"] = params_modifiers
+  # Forward deprecated kwargs so _enable_cache_impl on the worker can process them.
+  ctx.update(kwargs)
+
+  ray_kwargs = copy.deepcopy(ctx) if ctx else None
+  ray_qconfig = copy.deepcopy(quantize_config) if quantize_config is not None else None
+
+  from ..ray import enable_ray_parallelism
+  from ..ray import enable_ray_pipeline_parallelism
+
+  # BlockAdapter is not supported currently in Ray wrapper.
+  assert not isinstance(pipe_or_adapter,
+                        BlockAdapter), "BlockAdapter is not supported in Ray wrapper currently."
+
+  # Case 1: DiffusionPipeline
+  if isinstance(pipe_or_adapter, DiffusionPipeline):
+    return enable_ray_pipeline_parallelism(
+      pipe_or_adapter,
+      parallelism_config,
+      cache_context_kwargs=ray_kwargs,
+      quantize_config=ray_qconfig,
+    )
+
+  # Case 2: Transformer
+  return enable_ray_parallelism(
+    pipe_or_adapter,
+    parallelism_config,
+    cache_context_kwargs=ray_kwargs,
+    quantize_config=ray_qconfig,
+  )
+
+
+def _enable_cache_impl(
   # DiffusionPipeline or BlockAdapter
   pipe_or_adapter: Union[
     DiffusionPipeline,
@@ -164,13 +329,7 @@ def enable_cache(
     assert isinstance(quantize_config,
                       QuantizeConfig), "quantize_config should be of type QuantizeConfig."
 
-  ray_enabled = isinstance(parallelism_config, ParallelismConfig) and parallelism_config.use_ray
-  ray_cache_context_kwargs = copy.deepcopy(
-    context_kwargs) if ray_enabled and cache_config is not None else None
-  ray_quantize_config = copy.deepcopy(
-    quantize_config) if ray_enabled and quantize_config is not None else None
-
-  if cache_config is not None and not ray_enabled:
+  if cache_config is not None:
     if isinstance(
         pipe_or_adapter,
       (DiffusionPipeline, BlockAdapter, torch.nn.Module, ModelMixin),
@@ -183,8 +342,6 @@ def enable_cache(
       raise ValueError(f"type: {type(pipe_or_adapter)} is not valid, "
                        "Please pass DiffusionPipeline or BlockAdapter"
                        "for the 1's position param: pipe_or_adapter")
-  elif cache_config is not None:
-    logger.info("Ray parallelism is enabled; cache hooks will be applied inside Ray workers.")
   else:
     logger.warning("cache_config is None, skip cache acceleration for "
                    f"{pipe_or_adapter.__class__.__name__}.")
@@ -258,36 +415,12 @@ def enable_cache(
     if extra_parallel_module is not None and pipe is not None:
       parallelism_config.extra_parallel_modules = parse_extra_modules(pipe, extra_parallel_module)
 
-    if parallelism_config.use_ray:
-      from ..ray import enable_ray_parallelism
-      from ..ray import enable_ray_pipeline_parallelism
-
-      if isinstance(pipe_or_adapter, DiffusionPipeline):
-        pipe_or_adapter = enable_ray_pipeline_parallelism(
-          pipe_or_adapter,
-          parallelism_config,
-          cache_context_kwargs=ray_cache_context_kwargs,
-          quantize_config=ray_quantize_config,
-        )
-      else:
-        for i, transformer in enumerate(transformers):
-          transformers[i] = enable_ray_parallelism(
-            transformer,
-            parallelism_config,
-            cache_context_kwargs=ray_cache_context_kwargs,
-            quantize_config=ray_quantize_config,
-          )
-    else:
-      for i, transformer in enumerate(transformers):
-        # Enable parallelism for the transformer inplace
-        transformers[i] = enable_parallelism(transformer, parallelism_config)
+    for i, transformer in enumerate(transformers):
+      # Enable parallelism for the transformer inplace
+      transformers[i] = enable_parallelism(transformer, parallelism_config)
 
   # Enable quantization if quantize_config is provided.
   if quantize_config is not None:
-    if ray_enabled:
-      logger.info("Ray parallelism is enabled; quantization will be applied inside Ray workers.")
-      return pipe_or_adapter
-
     # By default, we will try to apply quantization to transformer module(s)
     # for better performance. User can specify the quantization modules more
     # precisely with quantize_config.components_to_quantize. For example,

--- a/src/cache_dit/caching/cache_interface.py
+++ b/src/cache_dit/caching/cache_interface.py
@@ -88,7 +88,10 @@ def enable_cache(
     >>> output = pipe(...)
     >>> stats = cache_dit.summary(pipe)
   """
-  ray_enabled = isinstance(parallelism_config, ParallelismConfig) and parallelism_config.use_ray
+  ray_enabled = isinstance(
+    parallelism_config,
+    ParallelismConfig,
+  ) and parallelism_config.use_ray
   if ray_enabled:
     return _enable_cache_with_ray_impl(
       pipe_or_adapter,

--- a/src/cache_dit/ray/worker.py
+++ b/src/cache_dit/ray/worker.py
@@ -11,11 +11,8 @@ from diffusers import DiffusionPipeline
 from diffusers.models.modeling_utils import ModelMixin
 
 from ..distributed import ParallelismConfig
-from ..distributed import enable_parallelism
 from ..logger import init_logger
 from ..quantization import QuantizeConfig
-from ..quantization import quantize
-from ..utils import parse_extra_modules
 from ._tree import cpu_tensor_tree
 from ._tree import device_tensor_tree
 from .dist import destroy_worker_process_group
@@ -84,75 +81,6 @@ def _maybe_compile_transformer(
   return transformer
 
 
-def _maybe_apply_cache(
-  module_or_pipe: torch.nn.Module | ModelMixin | DiffusionPipeline,
-  cache_context_kwargs: dict[str, Any] | None,
-) -> torch.nn.Module | ModelMixin | DiffusionPipeline:
-  """Apply cache hooks inside a Ray worker when cache config is provided.
-
-  :param module_or_pipe: Worker-local transformer or pipeline copy.
-  :param cache_context_kwargs: Cache context keyword arguments from ``cache_dit.enable_cache``.
-  :returns: The same object with cache hooks applied, when requested.
-  """
-
-  if cache_context_kwargs is None:
-    return module_or_pipe
-
-  from ..caching.cache_adapters import CachedAdapter
-
-  logger.info(f"Applying cache hooks inside Ray worker for {module_or_pipe.__class__.__name__}.")
-  return CachedAdapter.apply(module_or_pipe, **copy.deepcopy(cache_context_kwargs))
-
-
-def _maybe_quantize_transformer(
-  transformer: torch.nn.Module | ModelMixin,
-  quantize_config: QuantizeConfig | None,
-) -> torch.nn.Module | ModelMixin:
-  """Quantize a worker-local transformer when requested.
-
-  :param transformer: Worker-local transformer after cache and parallelism have been applied.
-  :param quantize_config: Optional quantization configuration.
-  :returns: Quantized transformer when requested, otherwise the original transformer.
-  """
-
-  if quantize_config is None:
-    return transformer
-  logger.info(f"Applying quantization inside Ray worker for {transformer.__class__.__name__}.")
-  return quantize(transformer, quantize_config=copy.deepcopy(quantize_config))
-
-
-def _maybe_quantize_pipeline(
-  pipe: DiffusionPipeline,
-  quantize_config: QuantizeConfig | None,
-) -> DiffusionPipeline:
-  """Quantize worker-local pipeline components when requested.
-
-  :param pipe: Worker-local pipeline after cache and transformer parallelism have been applied.
-  :param quantize_config: Optional quantization configuration.
-  :returns: Pipeline with requested components quantized.
-  """
-
-  if quantize_config is None:
-    return pipe
-  if quantize_config.components_to_quantize is None:
-    pipe.transformer = _maybe_quantize_transformer(pipe.transformer, quantize_config)
-    return pipe
-
-  expanded_quantize_configs = QuantizeConfig.expand_configs(quantize_config)
-  for config in expanded_quantize_configs:
-    components_to_quantize = config.components_to_quantize
-    components = parse_extra_modules(pipe, components_to_quantize)
-    assert len(components) == len(components_to_quantize), (
-      f"Some components in quantize_config.components_to_quantize: {components_to_quantize} "
-      "are not found in the pipeline, please check the component names or directly pass the "
-      "actual modules in components_to_quantize.")
-    for component, name in zip(components, components_to_quantize):
-      name = getattr(component, "_actual_module_name", name)
-      quantized_component = quantize(component, quantize_config=copy.deepcopy(config))
-      setattr(pipe, name, quantized_component)
-  return pipe
-
-
 class RayTransformerWorker:
   """Ray actor body that owns one rank of a cache-dit parallel transformer.
 
@@ -201,10 +129,17 @@ class RayTransformerWorker:
 
     self.transformer = transformer.to(self.device)
     self.transformer.eval()
-    self.transformer = _maybe_apply_cache(self.transformer, self.cache_context_kwargs)
-    if not self.parallelism_config._ray_skip_native_parallelism:
-      self.transformer = enable_parallelism(self.transformer, self.parallelism_config)
-    self.transformer = _maybe_quantize_transformer(self.transformer, self.quantize_config)
+    par_config = (self.parallelism_config
+                  if not self.parallelism_config._ray_skip_native_parallelism else None)
+    if self.cache_context_kwargs or par_config is not None or self.quantize_config is not None:
+      from ..caching.cache_interface import _enable_cache_impl
+      self.transformer = _enable_cache_impl(
+        self.transformer,
+        parallelism_config=par_config,
+        quantize_config=self.quantize_config,
+        attention_backend=self.parallelism_config.attention_backend,
+        **(self.cache_context_kwargs or {}),
+      )
     self.transformer = _maybe_compile_transformer(self.transformer, self.parallelism_config)
     return self.device_info()
 
@@ -245,10 +180,17 @@ class RayTransformerWorker:
     state_dict = load_file(path, device=str(self.device))
     transformer.load_state_dict(state_dict, assign=True)
     self.transformer = transformer.eval()
-    self.transformer = _maybe_apply_cache(self.transformer, self.cache_context_kwargs)
-    if not self.parallelism_config._ray_skip_native_parallelism:
-      self.transformer = enable_parallelism(self.transformer, self.parallelism_config)
-    self.transformer = _maybe_quantize_transformer(self.transformer, self.quantize_config)
+    par_config = (self.parallelism_config
+                  if not self.parallelism_config._ray_skip_native_parallelism else None)
+    if self.cache_context_kwargs or par_config is not None or self.quantize_config is not None:
+      from ..caching.cache_interface import _enable_cache_impl
+      self.transformer = _enable_cache_impl(
+        self.transformer,
+        parallelism_config=par_config,
+        quantize_config=self.quantize_config,
+        attention_backend=self.parallelism_config.attention_backend,
+        **(self.cache_context_kwargs or {}),
+      )
     self.transformer = _maybe_compile_transformer(self.transformer, self.parallelism_config)
     return self.device_info()
 
@@ -377,11 +319,18 @@ class RayPipelineWorker:
         component.to(self.device)
     self.pipe = pipe
     self.pipe.set_progress_bar_config(disable=True)
-    self.pipe = _maybe_apply_cache(self.pipe, self.cache_context_kwargs)
     self.pipe.transformer.eval()
-    if not self.parallelism_config._ray_skip_native_parallelism:
-      self.pipe.transformer = enable_parallelism(self.pipe.transformer, self.parallelism_config)
-    self.pipe = _maybe_quantize_pipeline(self.pipe, self.quantize_config)
+    par_config = (self.parallelism_config
+                  if not self.parallelism_config._ray_skip_native_parallelism else None)
+    if self.cache_context_kwargs or par_config is not None or self.quantize_config is not None:
+      from ..caching.cache_interface import _enable_cache_impl
+      self.pipe = _enable_cache_impl(
+        self.pipe,
+        parallelism_config=par_config,
+        quantize_config=self.quantize_config,
+        attention_backend=self.parallelism_config.attention_backend,
+        **(self.cache_context_kwargs or {}),
+      )
     self.pipe.transformer = _maybe_compile_transformer(
       self.pipe.transformer,
       self.parallelism_config,


### PR DESCRIPTION
```bash
python3 examples/ray/ray_wrapper_example.py \
  --model-path $FLUX_2_KLEIN_BASE_9B_DIR \
  --tp 2 \
  --compile --cache \
  --save-path ./tmp/ray_cache.png
Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 124.37it/s]
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 399/399 [00:00<00:00, 9971.56it/s]
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:01<00:00,  3.91it/s]
[05-25 12:04:24] [Cache-DiT] Auto selected parallelism backend for transformer: Native_PyTorch
2026-05-25 12:04:32,681	INFO worker.py:2013 -- Started a local Ray instance.
[05-25 12:05:24] [Cache-DiT] Ray pipeline worker placement before load: [{'rank': 0, 'device': 'cuda', 'cuda_visible_devices': '6', 'memory_allocated_mib': 0, 'memory_reserved_mib': 0}, {'rank': 1, 'device': 'cuda', 'cuda_visible_devices': '7', 'memory_allocated_mib': 0, 'memory_reserved_mib': 0}]
[05-25 12:05:24] [Cache-DiT] The main-process pipeline is already on CPU before Ray worker loading.
[05-25 12:05:24] [Cache-DiT] Saving the current pipeline snapshot for Ray workers to /workspace/dev/vipshop/cache-dit/.tmp/cache_dit_ray/5ff92be54fe645cfb4295beaa964da06/pipeline.
Writing model shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:17<00:00, 17.73s/it]
[05-25 12:06:02] [Cache-DiT] Saved the pipeline snapshot in 37.61s.
Loading pipeline components...:   0%|          | 0/5 [00:00<?, ?it/s]
Loading weights:   0%|          | 0/399 [00:00<?, ?it/s]
Loading weights: 100%|██████████| 399/399 [00:00<00:00, 9397.09it/s]
Loading pipeline components...:  20%|██        | 1/5 [00:01<00:05,  1.44s/it]
Loading checkpoint shards: 100%|██████████| 2/2 [00:00<00:00, 106.41it/s]
Loading weights: 100%|██████████| 399/399 [00:00<00:00, 9568.15it/s]
Loading pipeline components...: 100%|██████████| 5/5 [00:01<00:00,  3.01it/s]
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Flux2KleinPipeline is officially supported by cache-dit. Use it's pre-defined BlockAdapter directly!
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Auto fill blocks_name: ['transformer_blocks', 'single_transformer_blocks'].
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Match Block Forward Pattern: Flux2TransformerBlock, ForwardPattern.Pattern_1
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] IN:('hidden_states', 'encoder_hidden_states'), OUT:('encoder_hidden_states', 'hidden_states'))
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Match Block Forward Pattern: Flux2SingleTransformerBlock, ForwardPattern.Pattern_3
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] IN:('hidden_states',), OUT:('hidden_states',))
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Use default 'enable_separate_cfg' from block adapter register: False, Pipeline: Flux2KleinPipeline.
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Collected Context Config: DBCache_F1B0_W8I1M0MC0_R0.08_CFG0, Calibrator Config: None
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Collected Context Config: DBCache_F1B0_W8I1M0MC0_R0.08_CFG0, Calibrator Config: None
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Match Blocks: CachedBlocks_Pattern_0_1_2, for transformer_blocks, cache_context: transformer_blocks_139639897993680, context_manager: Flux2KleinPipeline_139641127455344.
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Match Blocks: CachedBlocks_Pattern_3_4_5, for single_transformer_blocks, cache_context: single_transformer_blocks_139639898257696, context_manager: Flux2KleinPipeline_139641127455344.
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Auto fill blocks_name: ['transformer_blocks', 'single_transformer_blocks'].
(RayPipelineWorker pid=3899811) [05-25 12:06:13] [Cache-DiT] Registered custom attn backends: native, flash, _sdpa_cudnn, sage, _native_npu, _npu_fia.
(RayPipelineWorker pid=3899811) [05-25 12:06:20] [Cache-DiT] Parallelize Transformer: Flux2Transformer2DModel, id:139639897993584, ParallelismConfig(backend=Native_PyTorch, tp_size=2)
(RayPipelineWorker pid=3899811) [05-25 12:06:22] [Cache-DiT] Compiling Ray-owned transformer with compile_repeated_blocks().
[05-25 12:06:23] [Cache-DiT] Loaded saved pipeline snapshots on Ray workers in 58.31s.
[05-25 12:06:23] [Cache-DiT] Ray pipeline worker placement after load: [{'rank': 0, 'device': 'cuda', 'cuda_visible_devices': '6', 'memory_allocated_mib': 24786, 'memory_reserved_mib': 25686}, {'rank': 1, 'device': 'cuda', 'cuda_visible_devices': '7', 'memory_allocated_mib': 24786, 'memory_reserved_mib': 25686}]
[05-25 12:06:23] [Cache-DiT] Enabled Ray parallelism for Flux2KleinPipeline with world_size=2.
Warmup: 1
Repeat: 1
Total Inference Time: 17.73s
Average Inference Time: 17.73s
Saved image to tmp/ray_cache.png
[05-25 12:07:10] [Cache-DiT] Acceleration hooks is disabled for: CacheDitRayFlux2KleinPipeline.
```

fixed https://github.com/vipshop/cache-dit/issues/1010