### PR TITLE
Fix Python version mismatch in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -325,7 +325,7 @@ setup(
   package_dir={"": "src"},
   packages=find_packages(where="src"),
   include_package_data=True,
-  python_requires=">=3.12",
+  python_requires=">=3.10",
   ext_modules=EXT_MODULES,
   cmdclass=CMDCLASS,
   entry_points={


### PR DESCRIPTION
Greetings DefTruth,

Thanks for your wonderful work.

pyproject.toml and the project documentation state that Python >=3.10 is supported.  However, setup.py hardcodes python_requires=">=3.12", which allows things like building cp310 wheels that won't install in cp310 environments.

This trivial PR updates setup.py to match pyproject.toml.

Best regards,
FNG