### PR TITLE
feat: config yaml support svdq dq/few-shot

### DIFF
--- a/docs/user_guide/LOAD_CONFIGS.md
+++ b/docs/user_guide/LOAD_CONFIGS.md
@@ -228,10 +228,44 @@ Then, apply the quantization config from yaml.
 >>> import cache_dit
 >>> cache_dit.enable_cache(pipe, **cache_dit.load_configs("quantize.yaml"))
 ```
+
 Please also enable torch.compile for better performance if you are using quantization.
 ```python
 cache_dit.set_compile_configs()
 pipe.transformer = torch.compile(pipe.transformer)
+```  
+
+For <span style="color:#c77dff;">SVDQuant W4A4 DQ</span> workflow, you can define a yaml file `quantize_svdquant.yaml` that contains:
+
+```yaml
+# Please install Cache-DiT with SVDQuant support (Experimental) before using the 
+# SVDQuant quantization config. Installation instructions:
+# `uv pip install -U cache-dit-cu13` or `CACHE_DIT_BUILD_SVDQUANT=1 uv pip install -e ".[quantization]"`
+quantize_config: 
+  quant_type: "svdq_int4_r128_dq" # or "svdq_nvfp4_r128_dq" for blackwell (sm120, sm121, etc.)
+  svdq_kwargs:
+    smooth_strategy: "few_shot"
+    few_shot_steps: 2
+    few_shot_auto_compile: true
+    # Device used for SVD decomposition and W4A4 packing math.
+    # - "cuda": force CUDA-side SVD + packing, even when float weights are on CPU.
+    # - "cpu":  force CPU-side SVD + packing (slow, for low-memory GPUs).
+    # - "auto": follow the module's current device (may resolve to CPU if the
+    #   pipeline has not been moved to CUDA yet, e.g. when loaded via config).
+    #
+    # IMPORTANT: `few_shot_auto_compile: true` REQUIRES `quantize_device: "cuda"`.
+    # Using "auto" or "cpu" together with `few_shot_auto_compile` is currently
+    # NOT supported: when SVD runs on CPU the newly materialised W4A4 weights
+    # stay on CPU, and while cache-dit attempts to move them to CUDA before
+    # compiling, the forward-pass inputs may still be on CPU, causing the SVDQ
+    # W4A4 CUDA kernel to assert.  If you need CPU-side SVD for low-memory
+    # scenarios, set `few_shot_auto_compile: false`, then compile manually after
+    # moving the pipeline to CUDA.
+    quantize_device: "cuda"
+  exclude_layers:  
+    - "embedder"
+    - "embed"
+  verbose: false
 ```
 
 - <span style="color:#c77dff;">fine-grained quantization</span>

--- a/examples/configs/blackwell/quantize_svdquant_sm120.yaml
+++ b/examples/configs/blackwell/quantize_svdquant_sm120.yaml
@@ -1,5 +1,5 @@
 quantize_config: 
-  quant_type: "svdq_int4_r128_dq" 
+  quant_type: "svdq_nvfp4_r128_dq" 
   svdq_kwargs:
     smooth_strategy: "few_shot"
     few_shot_steps: 2

--- a/examples/configs/quantize_svdquant.yaml
+++ b/examples/configs/quantize_svdquant.yaml
@@ -1,0 +1,27 @@
+quantize_config: 
+  quant_type: "svdq_int4_r128_dq" 
+  svdq_kwargs:
+    smooth_strategy: "few_shot"
+    few_shot_steps: 2
+    few_shot_auto_compile: true
+
+    # Device used for SVD decomposition and W4A4 packing math.
+    # - "cuda": force CUDA-side SVD + packing, even when float weights are on CPU.
+    # - "cpu":  force CPU-side SVD + packing (slow, for low-memory GPUs).
+    # - "auto": follow the module's current device (may resolve to CPU if the
+    #   pipeline has not been moved to CUDA yet, e.g. when loaded via config).
+    #
+    # IMPORTANT: `few_shot_auto_compile: true` REQUIRES `quantize_device: "cuda"`.
+    # Using "auto" or "cpu" together with `few_shot_auto_compile` is currently
+    # NOT supported: when SVD runs on CPU the newly materialised W4A4 weights
+    # stay on CPU, and while cache-dit attempts to move them to CUDA before
+    # compiling, the forward-pass inputs may still be on CPU, causing the SVDQ
+    # W4A4 CUDA kernel to assert.  If you need CPU-side SVD for low-memory
+    # scenarios, set `few_shot_auto_compile: false`, then compile manually after
+    # moving the pipeline to CUDA.
+    quantize_device: "cuda"
+
+  exclude_layers:  
+    - "embedder"
+    - "embed"
+  verbose: false

--- a/src/cache_dit/caching/load_configs.py
+++ b/src/cache_dit/caching/load_configs.py
@@ -339,7 +339,11 @@ def load_quantize_config(path_or_dict: str | dict, **kwargs) -> Optional[Quantiz
     raise ValueError("Input must be a file path (str) or a configuration dictionary (dict).")
   if "quantize_config" not in quantize_kwargs:
     return None
-  quantize_config = QuantizeConfig().update(**quantize_kwargs["quantize_config"])
+  _qc = quantize_kwargs["quantize_config"]
+  quantize_config = QuantizeConfig(**{
+    k: v
+    for k, v in _qc.items() if k in QuantizeConfig.__dataclass_fields__ and v is not None
+  })
   return quantize_config
 
 

--- a/src/cache_dit/quantization/config.py
+++ b/src/cache_dit/quantization/config.py
@@ -112,6 +112,14 @@ _SVDQ_KWARGS_DEFAULTS: dict[str, Any] = {
   "few_shot_relax_strategy": "auto",
   # Only valid for the DQ few-shot smooth strategy. When enabled, helper flows may defer
   # transformer compilation until runtime quantization completes.
+  # WARNING:
+  # `few_shot_auto_compile` currently REQUIRES ``quantize_device: "cuda"``.
+  # Using ``"auto"`` or ``"cpu"`` together with this flag is not supported:
+  # CPU-side SVD leaves W4A4 weights on CPU, and while cache-dit moves them
+  # to CUDA before compiling, the forward-pass inputs may still be on CPU,
+  # causing the SVDQ W4A4 CUDA kernel to assert.  If low-memory CPU-side SVD
+  # is needed, set this to ``False`` and compile manually after moving the
+  # pipeline to CUDA.
   "few_shot_auto_compile": False,
 }
 
@@ -410,6 +418,10 @@ class QuantizeConfig:
   # calibration callback but also quantization math, serialization metadata,
   # and load compatibility, so they are grouped under a validated backend-
   # specific dict instead of being exposed as many top-level config fields.
+  #
+  # .. note::
+  #    `few_shot_auto_compile` currently requires ``quantize_device: "cuda"``
+  #    inside ``svdq_kwargs``.  See the comment on that key for details.
   svdq_kwargs: Optional[Dict[str, Any]] = None
   # Whether to print detailed quantization information, such as the quantization
   # type of each layer, the reason for skipping quantization, etc. This is useful
@@ -564,6 +576,8 @@ class QuantizeConfig:
       if hasattr(self, key):
         if value is not None:
           setattr(self, key, value)
+    if "backend" not in kwargs:
+      self.backend = QuantizeBackend.AUTO
     self.__post_init__()
     return self
 

--- a/src/cache_dit/quantization/svdquant/ptq.py
+++ b/src/cache_dit/quantization/svdquant/ptq.py
@@ -100,6 +100,18 @@ def _infer_module_execution_device(module: nn.Module) -> torch.device:
     if execution_device is not None:
       return torch.device(execution_device)
 
+  # Prioritise nn.Linear (pre-quantisation) and SVDQW4A4Linear (post-quantisation)
+  # parameters — they are the SVDQ target layers and may reside on a different
+  # device than the rest of the model after CPU-side materialisation.
+  for submodule in module.modules():
+    if isinstance(submodule, (nn.Linear, SVDQW4A4Linear)):
+      try:
+        parameter = next(submodule.parameters())
+        if parameter.device.type != "meta":
+          return parameter.device
+      except StopIteration:
+        pass
+
   try:
     parameter = next(module.parameters())
     if parameter.device.type != "meta":
@@ -343,6 +355,19 @@ def _run_post_quantize_callbacks(
   callbacks = _pop_post_quantize_callbacks(module)
   if not callbacks and few_shot_auto_compile:
     try:
+      from ...compile.utils import set_compile_configs
+
+      set_compile_configs()
+      torch.set_float32_matmul_precision("high")
+      compile_device = _infer_module_execution_device(module)
+      if compile_device.type != "cuda":
+        cuda_device = torch.device("cuda", torch.cuda.current_device())
+        logger.info(
+          "Moving quantized module from %s to %s before compile.",
+          compile_device,
+          cuda_device,
+        )
+        module.to(cuda_device)
       if hasattr(module, "compile_repeated_blocks") and callable(module.compile_repeated_blocks):
         logger.info("Few-shot runtime quantization completed; compiling repeated blocks in-place.")
         module.compile_repeated_blocks()


### PR DESCRIPTION
fixed #1039 

```bash
python3 -m cache_dit.generate flux2_klein_4b --warmup 2 --repeat 2 --config configs/blackwell/quantize_svdquant_sm120.yaml
Unable to import `torchao` Tensor objects. This may affect loading checkpoints serialized with `torchao`
Loading weights: 100%|██████████████████████████████████████████████████████████████████████████████████████████████| 398/398 [00:00<00:00, 8807.24it/s]
Loading pipeline components...: 100%|█████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00,  7.19it/s]
[06-05 14:28:48] [Cache-DiT] Quantization config from configs/blackwell/quantize_svdquant_sm120.yaml: svdq_nvfp4_r128_dq_few_shot_auto
[06-05 14:28:48] [Cache-DiT] cache_config is None, skip cache acceleration for Flux2KleinPipeline.
[06-05 14:28:48] [Cache-DiT] SVDQuant few-shot runtime quantization for Flux2Transformer2DModel.
[06-05 14:28:48] [Cache-DiT] Observing 2 cumulative root forwards before materializing quantized linear layers;
[06-05 14:28:48] [Cache-DiT] Rerunning the same pipeline/module keeps advancing the same counter.
[06-05 14:28:48] [Cache-DiT] Applied acceleration config from file: configs/blackwell/quantize_svdquant_sm120.yaml.
 25%|█████████████████████████████▎                                                                                       | 1/4 [00:00<00:00,  3.64it/s][06-05 14:28:56] [Cache-DiT] ------------------------------------------------------------------------------
[06-05 14:28:56] [Cache-DiT] SVDQuant    Region: ['Flux2TransformerBlock', 'Flux2SingleTransformerBlock']  |
[06-05 14:28:56] [Cache-DiT] SVDQuant      Type: svdq_nvfp4_r128_dq                                        |
[06-05 14:28:56] [Cache-DiT] SVDQuant      Rank: 128                                                       |
[06-05 14:28:56] [Cache-DiT] Observed    Layers: 100 / 100                                                 |
[06-05 14:28:56] [Cache-DiT] Quantized   Layers: 100 / 100                                                 |
[06-05 14:28:56] [Cache-DiT] Skipped     Layers: 0                                                         |
[06-05 14:28:56] [Cache-DiT] Linear      Layers: 100                                                       |
[06-05 14:28:56] [Cache-DiT] ------------------------------------------------------------------------------
[06-05 14:28:56] [Cache-DiT] Few-shot runtime quantization completed; compiling repeated blocks in-place.
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:20<00:00,  5.07s/it]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 24.11it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 24.16it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 24.14it/s]
[06-05 14:29:14] [Cache-DiT] 🤖 Example Init Config Summary:
[06-05 14:29:14] [Cache-DiT] - Model: /root/autodl-tmp/models/FLUX.2-klein-4B
[06-05 14:29:14] [Cache-DiT] - Task Type: T2I - Text to Image
[06-05 14:29:14] [Cache-DiT] - Torch Dtype: torch.bfloat16
[06-05 14:29:14] [Cache-DiT] - Warmup Seed: None
[06-05 14:29:14] [Cache-DiT] - Warmup Prompt: None
[06-05 14:29:14] [Cache-DiT] - LoRA Weights: None
[06-05 14:29:14] [Cache-DiT] 🤖 Example Input Summary:
[06-05 14:29:14] [Cache-DiT] - prompt: A cute cat sitting on the beach, watching the sunset.
[06-05 14:29:14] [Cache-DiT] - height: 1024
[06-05 14:29:14] [Cache-DiT] - width: 1024
[06-05 14:29:14] [Cache-DiT] - guidance_scale: 1.0
[06-05 14:29:14] [Cache-DiT] - num_inference_steps: 4
[06-05 14:29:14] [Cache-DiT] - generator: device cpu, seed 0
[06-05 14:29:14] [Cache-DiT] 🤖 Example Output Summary:
[06-05 14:29:14] [Cache-DiT] - Model: flux2_klein_4b
[06-05 14:29:14] [Cache-DiT] - Optimization: C0_svdq_nvfp4_r128_dq_few_shot_auto
[06-05 14:29:14] [Cache-DiT] - Device: NVIDIA GeForce RTX 5090 x 1
[06-05 14:29:14] [Cache-DiT] - Load Time: 0.70s
[06-05 14:29:14] [Cache-DiT] - Warmup Time: 10.84s
[06-05 14:29:14] [Cache-DiT] - Inference Time: 0.49s
[06-05 14:29:15] [Cache-DiT] Image saved to flux2_klein_4b.1024x1024.C0_svdq_nvfp4_r128_dq_few_shot_auto.png
```