### PR TITLE
feat: support dynamic mode decomposition calibrator

### DIFF
--- a/src/cache_dit/__init__.py
+++ b/src/cache_dit/__init__.py
@@ -44,6 +44,7 @@ from .caching import DBPruneConfig
 from .caching import CalibratorConfig
 from .caching import TaylorSeerCalibratorConfig
 from .caching import FoCaCalibratorConfig
+from .caching import DMDCalibratorConfig
 from .caching import supported_pipelines
 from .caching import get_adapter
 from .caching import BlockAdapterRegister

--- a/src/cache_dit/_utils/utils.py
+++ b/src/cache_dit/_utils/utils.py
@@ -18,6 +18,7 @@ from ..attention import set_attn_backend
 from ..caching import (
   BlockAdapter,
   DBCacheConfig,
+  DMDCalibratorConfig,
   TaylorSeerCalibratorConfig,
   load_configs,
   load_parallelism_config,
@@ -308,6 +309,18 @@ def get_args(parse: bool = True, ) -> argparse.ArgumentParser | argparse.Namespa
     type=int,
     default=1,
     help="TaylorSeer order",
+  )
+  parser.add_argument(
+    "--dmd",
+    action="store_true",
+    default=False,
+    help="Enable DMD (Dynamic Mode Decomposition / Prony) exponential-basis calibrator for CacheDiT",
+  )
+  parser.add_argument(
+    "--dmd-history",
+    type=int,
+    default=6,
+    help="DMD snapshot-history window length",
   )
   parser.add_argument(
     "--steps-mask",
@@ -2282,8 +2295,9 @@ def maybe_apply_optimization(
           force_refresh_step_hint=kwargs.get("force_refresh_step_hint", None),
           force_refresh_step_policy=kwargs.get("force_refresh_step_policy", "once"),
         ) if cache_config is None and args.cache else cache_config),
-        calibrator_config=(TaylorSeerCalibratorConfig(taylorseer_order=args.taylorseer_order, )
-                           if args.taylorseer else None),
+        calibrator_config=(DMDCalibratorConfig(
+          dmd_history=args.dmd_history) if args.dmd else TaylorSeerCalibratorConfig(
+            taylorseer_order=args.taylorseer_order) if args.taylorseer else None),
         params_modifiers=kwargs.get("params_modifiers", None),
         parallelism_config=(ParallelismConfig(
           ulysses_size=ulysses_size,

--- a/src/cache_dit/caching/__init__.py
+++ b/src/cache_dit/caching/__init__.py
@@ -21,6 +21,7 @@ from .cache_contexts import ContextManager
 from .cache_contexts import CalibratorConfig
 from .cache_contexts import TaylorSeerCalibratorConfig
 from .cache_contexts import FoCaCalibratorConfig
+from .cache_contexts import DMDCalibratorConfig
 
 from .cache_blocks import CachedBlocks
 from .cache_blocks import PrunedBlocks

--- a/src/cache_dit/caching/cache_contexts/__init__.py
+++ b/src/cache_dit/caching/cache_contexts/__init__.py
@@ -4,6 +4,7 @@ from .calibrators import (
   CalibratorConfig,
   TaylorSeerCalibratorConfig,
   FoCaCalibratorConfig,
+  DMDCalibratorConfig,
 )
 from .cache_config import (
   BasicCacheConfig,

--- a/src/cache_dit/caching/cache_contexts/calibrators/__init__.py
+++ b/src/cache_dit/caching/cache_contexts/calibrators/__init__.py
@@ -158,12 +158,11 @@ class TaylorSeerCalibratorConfig(CalibratorConfig):
 class DMDCalibratorConfig(CalibratorConfig):
   """Config for the Dynamic Mode Decomposition (Prony) forecasting calibrator.
 
-  An EXPONENTIAL-basis alternative to TaylorSeer's polynomial forecast: DMD
-  (Schmid 2010; the SVD-regularised generalisation of Prony's method) identifies
-  the linear propagator of the cached feature stream from recent compute-step
-  snapshots and extrapolates by eigenvalue powers — exact on the (locally)
-  exponential trajectories diffusion features follow, where a polynomial
-  diverges with the cache interval. NOT Distribution Matching Distillation.
+  An EXPONENTIAL-basis alternative to TaylorSeer's polynomial forecast: DMD (Schmid 2010; the SVD-
+  regularised generalisation of Prony's method) identifies the linear propagator of the cached
+  feature stream from recent compute-step snapshots and extrapolates by eigenvalue powers — exact on
+  the (locally) exponential trajectories diffusion features follow, where a polynomial diverges with
+  the cache interval. NOT Distribution Matching Distillation.
   """
 
   # enable_calibrator (`bool`, *required*,  defaults to True):

--- a/src/cache_dit/caching/cache_contexts/calibrators/__init__.py
+++ b/src/cache_dit/caching/cache_contexts/calibrators/__init__.py
@@ -1,6 +1,7 @@
 from .base import CalibratorBase
 from .taylorseer import TaylorSeerCalibrator
 from .foca import FoCaCalibrator
+from .dmd import DMDCalibrator
 
 import dataclasses
 from typing import Any, Dict
@@ -154,6 +155,71 @@ class TaylorSeerCalibratorConfig(CalibratorConfig):
 
 
 @dataclasses.dataclass
+class DMDCalibratorConfig(CalibratorConfig):
+  """Config for the Dynamic Mode Decomposition (Prony) forecasting calibrator.
+
+  An EXPONENTIAL-basis alternative to TaylorSeer's polynomial forecast: DMD
+  (Schmid 2010; the SVD-regularised generalisation of Prony's method) identifies
+  the linear propagator of the cached feature stream from recent compute-step
+  snapshots and extrapolates by eigenvalue powers — exact on the (locally)
+  exponential trajectories diffusion features follow, where a polynomial
+  diverges with the cache interval. NOT Distribution Matching Distillation.
+  """
+
+  # enable_calibrator (`bool`, *required*,  defaults to True):
+  #     Whether to enable calibrator, if True. means that user want to use DBCache
+  #     with specific calibrator for hidden_states (or hidden_states redisual),
+  #     such as taylorseer, foca, dmd, and so on.
+  enable_calibrator: bool = True
+  # enable_encoder_calibrator (`bool`, *required*,  defaults to True):
+  #     Whether to enable calibrator, if True. means that user want to use DBCache
+  #     with specific calibrator for encoder_hidden_states (or encoder_hidden_states
+  #     redisual), such as taylorseer, foca, dmd, and so on.
+  enable_encoder_calibrator: bool = True
+  # calibrator_type (`str`, *required*,  defaults to 'dmd'):
+  #    The specific type for calibrator, taylorseer, foca or dmd, etc.
+  calibrator_type: str = "dmd"
+  # dmd_history (`int`, *required*, defaults to 6):
+  #    Number of recent compute-step snapshots retained per stream. >= 4 uniformly
+  #    spaced snapshots are needed before the exponential fit engages (one complex
+  #    pole costs two real degrees of freedom); below the floor the calibrator
+  #    falls back to the Taylor expansion automatically. 5-6 is the sweet spot —
+  #    the feature dynamics drift across timesteps, so longer windows hurt.
+  dmd_history: int = 6
+  # dmd_rank (`int`, *optional*, defaults to 0):
+  #    SVD truncation rank of the snapshot matrix; 0 selects it from the spectrum
+  #    (drop modes below 1e-4 of the leading singular value). The truncation is
+  #    what rejects the noise subspace.
+  dmd_rank: int = 0
+  # dmd_ridge (`float`, *optional*, defaults to 1e-8):
+  #    Tikhonov term added to the inverted singular values.
+  dmd_ridge: float = 1e-8
+
+  def strify(self, **kwargs) -> str:
+    """Return a compact tag that includes the snapshot-history length.
+
+    :param kwargs: Additional keyword arguments forwarded to the underlying implementation.
+    :returns: A compact DMD tag for logs, summaries, or filenames.
+    """
+
+    if kwargs.get("details", False):
+      return f"DMD_H({self.dmd_history})"
+    return f"DMDH{self.dmd_history}"
+
+  def to_kwargs(self) -> Dict:
+    """Translate config fields into `DMDCalibrator` init kwargs.
+
+    :returns: Keyword arguments expected by `DMDCalibrator`.
+    """
+
+    kwargs = self.calibrator_kwargs.copy()
+    kwargs["history"] = self.dmd_history
+    kwargs["rank"] = self.dmd_rank
+    kwargs["ridge"] = self.dmd_ridge
+    return kwargs
+
+
+@dataclasses.dataclass
 class FoCaCalibratorConfig(CalibratorConfig):
   """Config placeholder for the future FoCa calibrator backend."""
 
@@ -183,6 +249,7 @@ class Calibrator:
 
   _supported_calibrators = [
     "taylorseer",
+    "dmd",
     # TODO: FoCa
   ]
 
@@ -201,5 +268,7 @@ class Calibrator:
 
     if calibrator_config.calibrator_type.lower() == "taylorseer":
       return TaylorSeerCalibrator(**calibrator_config.to_kwargs())
+    elif calibrator_config.calibrator_type.lower() == "dmd":
+      return DMDCalibrator(**calibrator_config.to_kwargs())
     else:
       raise ValueError(f"Calibrator {calibrator_config.calibrator_type} is not supported now!")

--- a/src/cache_dit/caching/cache_contexts/calibrators/dmd.py
+++ b/src/cache_dit/caching/cache_contexts/calibrators/dmd.py
@@ -1,0 +1,338 @@
+# Dynamic Mode Decomposition (Prony) calibrator — an EXPONENTIAL-basis alternative
+# to the TaylorSeer polynomial forecaster. Note: "DMD" here is Dynamic Mode
+# Decomposition (Schmid 2010; the SVD-regularised, multivariate generalisation of
+# Prony's method, 1795), NOT Distribution Matching Distillation.
+#
+# Why an exponential basis: across denoising steps the cached feature/residual
+# evolves under a (slowly varying) near-linear operator, so locally it is a sum of
+# damped / oscillatory EXPONENTIALS — the exact solution class of a linear ODE.
+# A polynomial (Taylor) forecast is only a local truncation of that class and
+# diverges as the skip horizon grows; the exponential basis is exact on the class,
+# so it keeps quality at larger cache intervals.
+import math
+from typing import Dict, List, Tuple
+
+import torch
+
+from .base import CalibratorBase
+
+from ....logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _dmd_forecast(
+  snapshots: List[torch.Tensor],
+  k: float,
+  rank: int = 0,
+  ridge: float = 1e-8,
+) -> torch.Tensor:
+  """Forecast a feature ``k`` snapshot-spacings past the newest snapshot via
+  Dynamic Mode Decomposition (Prony).
+
+  Identify the linear propagator ``A`` from the snapshot pairs
+  (``Y_{t+1} ~= A Y_t``) through one economy SVD, eigendecompose it once, and
+  advance by (possibly fractional) eigenvalue powers::
+
+      Y_{t+k} ~= Phi @ (lambda**k * b),   b = pinv(Phi) @ Y_t
+
+  :param snapshots: >= 3 same-shape tensors, OLDEST..NEWEST, the fully computed
+      features at recent compute steps (uniformly spaced).
+  :param k: Forecast horizon in snapshot-spacing units (fractional allowed).
+  :param rank: SVD truncation rank; 0 selects it from the spectrum (drop modes
+      below 1e-4 of the leading singular value — this is what rejects noise).
+  :param ridge: Tikhonov term added to the inverted singular values.
+  :returns: Forecast tensor of the snapshot shape; falls back to last-value
+      reuse when the history is too short or the fit is degenerate.
+  """
+
+  shp, dt = snapshots[-1].shape, snapshots[-1].dtype
+  if len(snapshots) < 3:
+    return snapshots[-1].clone()
+  V = torch.stack([s.reshape(-1) for s in snapshots], dim=1).to(torch.float64)
+  X, Xp = V[:, :-1], V[:, 1:]
+  try:
+    U, S, Vh = torch.linalg.svd(X, full_matrices=False)
+  except Exception:  # noqa: BLE001 — degenerate fit: fall back to last-value reuse
+    return snapshots[-1].clone()
+  if rank <= 0:
+    rank = int((S > S[0] * 1e-4).sum().clamp(min=1).item())
+  rank = max(1, min(rank, S.numel()))
+  Ur, Sr, Vr = U[:, :rank], S[:rank], Vh[:rank].mH
+  Sinv = (1.0 / (Sr + ridge)).to(torch.complex128)
+  Atil = (Ur.mH @ Xp @ Vr).to(torch.complex128) * Sinv.unsqueeze(0)
+  try:
+    evals, W = torch.linalg.eig(Atil)
+    Phi = ((Xp @ Vr).to(torch.complex128) * Sinv.unsqueeze(0)) @ W
+    b = torch.linalg.lstsq(Phi, V[:, -1].to(torch.complex128).unsqueeze(1)).solution.squeeze(1)
+  except Exception:  # noqa: BLE001 — degenerate fit: fall back to last-value reuse
+    return snapshots[-1].clone()
+  pred = (Phi @ (evals.pow(float(k)) * b)).real
+  if not torch.isfinite(pred).all():
+    return snapshots[-1].clone()
+  return pred.to(dt).reshape(shp)
+
+
+class DMDState:
+  """Per-stream snapshot history + Taylor fallback for one calibration stream."""
+
+  def __init__(
+    self,
+    history: int = 6,
+    rank: int = 0,
+    ridge: float = 1e-8,
+    n_derivatives: int = 1,
+  ):
+    """Initialize snapshot buffers and the polynomial-fallback ladder.
+
+    :param history: Number of recent compute-step snapshots retained. Kept
+        short on purpose: the feature dynamics are non-autonomous (the
+        propagator drifts across timesteps), so a long window would average
+        over changing dynamics.
+    :param rank: SVD truncation rank for the DMD fit (0 = automatic).
+    :param ridge: Tikhonov regulariser for the DMD fit.
+    :param n_derivatives: Taylor orders kept for the warm-up fallback.
+    """
+
+    self.history = history
+    self.rank = rank
+    self.ridge = ridge
+    self.n_derivatives = n_derivatives
+    self.order = n_derivatives + 1
+    self.current_step = -1
+    self.last_non_approximated_step = -1
+    self.snapshots: List[Tuple[int, torch.Tensor]] = []
+    self.state: Dict[str, List[torch.Tensor]] = {
+      "dY_prev": [None] * self.order,
+      "dY_current": [None] * self.order,
+    }
+
+  def reset(self):
+    """Reset snapshot history, fallback buffers, and step counters."""
+
+    self.current_step = -1
+    self.last_non_approximated_step = -1
+    self.snapshots = []
+    self.state = {
+      "dY_prev": [None] * self.order,
+      "dY_current": [None] * self.order,
+    }
+
+  def mark_step_begin(self):
+    """Advance the logical step counter by one."""
+
+    self.current_step += 1
+
+  def _update_taylor(self, Y: torch.Tensor):
+    """Maintain the TaylorSeer divided-difference ladder (warm-up fallback)."""
+
+    dY_current: List[torch.Tensor] = [None] * self.order
+    dY_current[0] = Y
+    window = self.current_step - self.last_non_approximated_step
+    if self.state["dY_prev"][0] is not None:
+      if dY_current[0].shape != self.state["dY_prev"][0].shape:
+        self.reset()
+    for i in range(self.n_derivatives):
+      if self.state["dY_prev"][i] is not None and self.current_step > 1 and window > 0:
+        dY_current[i + 1] = (dY_current[i] - self.state["dY_prev"][i]) / window
+      else:
+        break
+    self.state["dY_prev"] = self.state["dY_current"]
+    self.state["dY_current"] = dY_current
+
+  def _approximate_taylor(self) -> torch.Tensor:
+    """Taylor-expansion fallback, identical to `TaylorSeerState.approximate`."""
+
+    elapsed = self.current_step - self.last_non_approximated_step
+    output = 0
+    for i, derivative in enumerate(self.state["dY_current"]):
+      if derivative is not None:
+        output += (1 / math.factorial(i)) * derivative * (elapsed ** i)
+      else:
+        break
+    return output
+
+  def update(self, Y: torch.Tensor):
+    """Commit a fully computed tensor as the newest snapshot / anchor.
+
+    :param Y: Fully computed tensor to record at the current step.
+    """
+
+    if self.snapshots and self.snapshots[-1][1].shape != Y.shape:
+      self.reset()
+    self._update_taylor(Y)
+    # detach().clone(): a bare detached view shares storage with the pipeline
+    # tensor, so buffer-reusing inference (torch.compile / CUDA graphs) could
+    # silently overwrite the snapshot history in place.
+    self.snapshots.append((self.current_step, Y.detach().clone()))
+    if len(self.snapshots) > self.history:
+      del self.snapshots[: len(self.snapshots) - self.history]
+    self.last_non_approximated_step = self.current_step
+
+  def _uniform_tail(self) -> Tuple[List[torch.Tensor], int]:
+    """Longest uniformly spaced suffix of the snapshot history.
+
+    The DMD propagator advances exactly one snapshot-spacing per application,
+    so a mixed-spacing window (e.g. across the warm-up boundary, or when the
+    dynamic cache changes its compute cadence) would corrupt the fit.
+
+    :returns: (velocities OLDEST..NEWEST, spacing) — empty list when degenerate.
+    """
+
+    if len(self.snapshots) < 2:
+      return [], 0
+    steps = [s for s, _ in self.snapshots]
+    spacing = steps[-1] - steps[-2]
+    if spacing <= 0:
+      return [], 0
+    tail = [self.snapshots[-1], self.snapshots[-2]]
+    j = len(self.snapshots) - 2
+    while j - 1 >= 0 and steps[j] - steps[j - 1] == spacing:
+      tail.append(self.snapshots[j - 1])
+      j -= 1
+    return [v for _, v in reversed(tail)], spacing
+
+  def approximate(self) -> torch.Tensor:
+    """Forecast the tensor for the current step.
+
+    Uses the exponential Dynamic Mode Decomposition (Prony) forecast on the
+    uniformly spaced snapshot tail with a fractional horizon
+    ``(current_step - last_compute_step) / spacing``. Below the 4-snapshot
+    identifiability floor (a real trajectory spends two real degrees of
+    freedom per complex pole, so even one oscillatory mode needs 3 snapshot
+    pairs) it falls back to the Taylor expansion — DMD acts only where it is
+    valid and the polynomial path covers warm-up.
+
+    :returns: The forecast tensor for the current logical step.
+    """
+
+    vels, spacing = self._uniform_tail()
+    if len(vels) >= 4:
+      k = (self.current_step - self.snapshots[-1][0]) / spacing
+      return _dmd_forecast(vels, k, rank=self.rank, ridge=self.ridge)
+    return self._approximate_taylor()
+
+  def step(self, Y: torch.Tensor):
+    """Advance one step and return either the true tensor or its forecast.
+
+    :param Y: Fully computed tensor when compute is required.
+    :returns: The exact tensor or the DMD/Taylor forecast for this step.
+    """
+
+    self.mark_step_begin()
+    if self.last_non_approximated_step < 0:
+      self.update(Y)
+      return Y
+    return self.approximate()
+
+
+class DMDCalibrator(CalibratorBase):
+  """Calibrator that forecasts tensors with a Dynamic Mode Decomposition
+  (Prony) exponential basis — drop-in alternative to `TaylorSeerCalibrator`."""
+
+  def __init__(
+    self,
+    history: int = 6,
+    rank: int = 0,
+    ridge: float = 1e-8,
+    n_derivatives: int = 1,
+    **kwargs,
+  ):
+    """Create a calibrator whose states are keyed by logical tensor names.
+
+    :param history: Snapshot window length retained per stream (5–6 typical).
+    :param rank: SVD truncation rank for the DMD fit (0 = automatic).
+    :param ridge: Tikhonov regulariser for the DMD fit.
+    :param n_derivatives: Taylor orders for the warm-up fallback ladder.
+    :param kwargs: Additional keyword arguments forwarded to the underlying implementation.
+    """
+
+    self.history = history
+    self.rank = rank
+    self.ridge = ridge
+    self.n_derivatives = n_derivatives
+    self.states: Dict[str, DMDState] = {}
+    self.reset_cache()
+
+  def reset_cache(self):
+    """Reset every tracked `DMDState` without dropping the key mapping."""
+
+    if self.states:
+      for state in self.states.values():
+        state.reset()
+
+  def maybe_init_state(
+    self,
+    name: str = "default",
+  ):
+    """Lazily create one DMD state for a named tensor stream.
+
+    :param name: Logical tensor-stream name.
+    """
+
+    if name not in self.states:
+      self.states[name] = DMDState(
+        history=self.history,
+        rank=self.rank,
+        ridge=self.ridge,
+        n_derivatives=self.n_derivatives,
+      )
+
+  def mark_step_begin(self, *args, **kwargs):
+    """Advance every tracked state's step counter.
+
+    :param args: Additional positional arguments forwarded to the underlying implementation.
+    :param kwargs: Additional keyword arguments forwarded to the underlying implementation.
+    """
+
+    if self.states:
+      for state in self.states.values():
+        state.mark_step_begin()
+
+  def approximate(
+    self,
+    name: str = "default",
+  ) -> torch.Tensor:
+    """Forecast the next tensor for one named stream.
+
+    :param name: Logical tensor-stream name.
+    :returns: The forecast tensor for the named stream.
+    """
+
+    assert name in self.states, f"State '{name}' not found."
+    state = self.states[name]
+    return state.approximate()
+
+  def update(
+    self,
+    Y: torch.Tensor,
+    name: str = "default",
+  ):
+    """Feed a fully computed tensor into one named DMD state.
+
+    :param Y: Fully computed tensor for the named stream.
+    :param name: Logical tensor-stream name.
+    """
+
+    self.maybe_init_state(name)
+    state = self.states[name]
+    state.update(Y)
+
+  def step(
+    self,
+    Y: torch.Tensor,
+    name: str = "default",
+  ):
+    """Advance one named stream and return either computed or forecast output.
+
+    :param Y: Fully computed tensor for the named stream when computation is required.
+    :param name: Logical tensor-stream name.
+    :returns: The exact tensor or DMD forecast for the named stream.
+    """
+
+    self.maybe_init_state(name)
+    state = self.states[name]
+    return state.step(Y)
+
+  def __repr__(self):
+    return f"DMDCalibrator_H({self.history})"

--- a/src/cache_dit/caching/cache_contexts/calibrators/dmd.py
+++ b/src/cache_dit/caching/cache_contexts/calibrators/dmd.py
@@ -21,56 +21,99 @@ from ....logger import init_logger
 logger = init_logger(__name__)
 
 
-def _dmd_forecast(
-  snapshots: List[torch.Tensor],
-  k: float,
+def _dmd_fit_one(
+  traj: torch.Tensor,
   rank: int = 0,
   ridge: float = 1e-8,
-) -> torch.Tensor:
-  """Forecast a feature ``k`` snapshot-spacings past the newest snapshot via
-  Dynamic Mode Decomposition (Prony).
+):
+  """Fit the DMD eigendecomposition for ONE ``[d, n]`` trajectory (a single batch item's snapshot
+  history, columns OLDEST..NEWEST).
 
   Identify the linear propagator ``A`` from the snapshot pairs
-  (``Y_{t+1} ~= A Y_t``) through one economy SVD, eigendecompose it once, and
-  advance by (possibly fractional) eigenvalue powers::
+  (``Y_{t+1} ~= A Y_t``) through one economy SVD and eigendecompose it once. The
+  fit is horizon-free, so the caller caches it and advances it cheaply (see
+  :func:`_dmd_eval`).
 
-      Y_{t+k} ~= Phi @ (lambda**k * b),   b = pinv(Phi) @ Y_t
-
-  :param snapshots: >= 3 same-shape tensors, OLDEST..NEWEST, the fully computed
-      features at recent compute steps (uniformly spaced).
-  :param k: Forecast horizon in snapshot-spacing units (fractional allowed).
   :param rank: SVD truncation rank; 0 selects it from the spectrum (drop modes
       below 1e-4 of the leading singular value — this is what rejects noise).
   :param ridge: Tikhonov term added to the inverted singular values.
-  :returns: Forecast tensor of the snapshot shape; falls back to last-value
-      reuse when the history is too short or the fit is degenerate.
+  :returns: ``(Phi, evals, b)`` or ``None`` on a degenerate fit (caller reuses
+      the last value).
   """
 
-  shp, dt = snapshots[-1].shape, snapshots[-1].dtype
-  if len(snapshots) < 3:
-    return snapshots[-1].clone()
-  V = torch.stack([s.reshape(-1) for s in snapshots], dim=1).to(torch.float64)
-  X, Xp = V[:, :-1], V[:, 1:]
+  X, Xp = traj[:, :-1], traj[:, 1:]
   try:
     U, S, Vh = torch.linalg.svd(X, full_matrices=False)
-  except Exception:  # noqa: BLE001 — degenerate fit: fall back to last-value reuse
-    return snapshots[-1].clone()
-  if rank <= 0:
-    rank = int((S > S[0] * 1e-4).sum().clamp(min=1).item())
-  rank = max(1, min(rank, S.numel()))
-  Ur, Sr, Vr = U[:, :rank], S[:rank], Vh[:rank].mH
+  except Exception:  # noqa: BLE001 — degenerate fit: caller falls back to reuse
+    return None
+  r = rank
+  if r <= 0:
+    r = int((S > S[0] * 1e-4).sum().clamp(min=1).item())
+  r = max(1, min(r, S.numel()))
+  Ur, Sr, Vr = U[:, :r], S[:r], Vh[:r].mH
   Sinv = (1.0 / (Sr + ridge)).to(torch.complex128)
   Atil = (Ur.mH @ Xp @ Vr).to(torch.complex128) * Sinv.unsqueeze(0)
   try:
     evals, W = torch.linalg.eig(Atil)
     Phi = ((Xp @ Vr).to(torch.complex128) * Sinv.unsqueeze(0)) @ W
-    b = torch.linalg.lstsq(Phi, V[:, -1].to(torch.complex128).unsqueeze(1)).solution.squeeze(1)
-  except Exception:  # noqa: BLE001 — degenerate fit: fall back to last-value reuse
-    return snapshots[-1].clone()
-  pred = (Phi @ (evals.pow(float(k)) * b)).real
-  if not torch.isfinite(pred).all():
-    return snapshots[-1].clone()
-  return pred.to(dt).reshape(shp)
+    b = torch.linalg.lstsq(Phi, traj[:, -1].to(torch.complex128).unsqueeze(1)).solution.squeeze(1)
+  except Exception:  # noqa: BLE001 — degenerate fit: caller falls back to reuse
+    return None
+  return (Phi, evals, b)
+
+
+def _dmd_fit(
+  snapshots: List[torch.Tensor],
+  rank: int = 0,
+  ridge: float = 1e-8,
+):
+  """Fit DMD once for a window of >= 4 same-shape snapshots, INDEPENDENTLY per batch item (axis 0).
+
+  Flattening the whole tensor into a single state (the pre-fix behaviour) folds
+  the batch dimension into one DMD fit, so one prompt's forecast would depend on
+  the other prompts in the same batch — unlike the elementwise Taylor path.
+  Fitting per batch item keeps them independent. The fit is horizon-free, so
+  :class:`DMDState` caches the returned object and reuses it for every skip step
+  until a new snapshot arrives (one SVD/eig per window, not per skipped step).
+
+  :returns: ``(per_item_fits, shape, dtype)``, or ``None`` when the window is
+      too short. ``per_item_fits[i]`` is ``None`` for a degenerate batch item.
+  """
+
+  if len(snapshots) < 4:
+    return None
+  newest = snapshots[-1]
+  shp, dt = newest.shape, newest.dtype
+  bsz = shp[0] if newest.dim() > 1 else 1
+  # (B, d, n): per-item trajectories; B == 1 reproduces the un-batched fit.
+  V = torch.stack([s.reshape(bsz, -1) for s in snapshots], dim=-1).to(torch.float64)
+  fits = [_dmd_fit_one(V[i], rank=rank, ridge=ridge) for i in range(bsz)]
+  return (fits, shp, dt)
+
+
+def _dmd_eval(fit, k: float):
+  """Advance a cached :func:`_dmd_fit` to (fractional) horizon ``k`` by eigenvalue powers —
+  ``Y_{t+k} ~= Phi @ (lambda**k * b)`` — one cheap evaluation per batch item, no re-decomposition.
+
+  :returns: The forecast tensor of the original snapshot shape, or ``None`` when
+      any batch item is degenerate, or when the result is non-finite AFTER the
+      output-dtype cast. The finite check is deliberately post-cast: a finite
+      float64 forecast can still overflow to ``inf`` in fp16, which the caller
+      must catch and fall back from rather than feed downstream.
+  """
+
+  fits, shp, dt = fit
+  rows = []
+  for f in fits:
+    if f is None:
+      return None
+    Phi, evals, b = f
+    rows.append((Phi @ (evals.pow(float(k)) * b)).real)
+  pred = torch.stack(rows, dim=0) if len(shp) > 1 else rows[0]
+  out = pred.to(dt).reshape(shp)
+  if not torch.isfinite(out).all():
+    return None
+  return out
 
 
 class DMDState:
@@ -102,6 +145,10 @@ class DMDState:
     self.current_step = -1
     self.last_non_approximated_step = -1
     self.snapshots: List[Tuple[int, torch.Tensor]] = []
+    # Cached horizon-free DMD fit + the window key it was fitted on, so skip
+    # steps reuse one SVD/eig instead of recomputing it every step.
+    self._fit = None
+    self._fit_key = None
     self.state: Dict[str, List[torch.Tensor]] = {
       "dY_prev": [None] * self.order,
       "dY_current": [None] * self.order,
@@ -113,6 +160,8 @@ class DMDState:
     self.current_step = -1
     self.last_non_approximated_step = -1
     self.snapshots = []
+    self._fit = None
+    self._fit_key = None
     self.state = {
       "dY_prev": [None] * self.order,
       "dY_current": [None] * self.order,
@@ -166,8 +215,10 @@ class DMDState:
     # silently overwrite the snapshot history in place.
     self.snapshots.append((self.current_step, Y.detach().clone()))
     if len(self.snapshots) > self.history:
-      del self.snapshots[: len(self.snapshots) - self.history]
+      del self.snapshots[:len(self.snapshots) - self.history]
     self.last_non_approximated_step = self.current_step
+    # A new snapshot changes the window, so the cached fit is stale.
+    self._fit_key = None
 
   def _uniform_tail(self) -> Tuple[List[torch.Tensor], int]:
     """Longest uniformly spaced suffix of the snapshot history.
@@ -203,13 +254,26 @@ class DMDState:
     pairs) it falls back to the Taylor expansion — DMD acts only where it is
     valid and the polynomial path covers warm-up.
 
+    The eigendecomposition depends only on the snapshot window, which cannot
+    change between two skip steps, so it is fitted once per window and cached;
+    each skip step only re-advances the cheap ``lambda**k`` horizon. A
+    degenerate fit or non-finite forecast reuses the newest snapshot.
+
     :returns: The forecast tensor for the current logical step.
     """
 
     vels, spacing = self._uniform_tail()
     if len(vels) >= 4:
       k = (self.current_step - self.snapshots[-1][0]) / spacing
-      return _dmd_forecast(vels, k, rank=self.rank, ridge=self.ridge)
+      key = (self.snapshots[-1][0], len(vels), spacing)
+      if self._fit_key != key:
+        self._fit = _dmd_fit(vels, rank=self.rank, ridge=self.ridge)
+        self._fit_key = key
+      if self._fit is not None:
+        pred = _dmd_eval(self._fit, k)
+        if pred is not None:
+          return pred
+      return self.snapshots[-1][1].clone()
     return self._approximate_taylor()
 
   def step(self, Y: torch.Tensor):
@@ -227,8 +291,8 @@ class DMDState:
 
 
 class DMDCalibrator(CalibratorBase):
-  """Calibrator that forecasts tensors with a Dynamic Mode Decomposition
-  (Prony) exponential basis — drop-in alternative to `TaylorSeerCalibrator`."""
+  """Calibrator that forecasts tensors with a Dynamic Mode Decomposition (Prony) exponential basis —
+  drop-in alternative to `TaylorSeerCalibrator`."""
 
   def __init__(
     self,


### PR DESCRIPTION
# Add a Dynamic Mode Decomposition (Prony) exponential-basis calibrator (`calibrator_type="dmd"`)

## Motivation

cache-dit's calibrators currently forecast cached hidden states / residuals with the
TaylorSeer **polynomial** expansion. This PR adds a second, drop-in calibrator backend
with an **exponential** forecast basis: **Dynamic Mode Decomposition** (Schmid 2010), the
SVD-regularised multivariate generalisation of **Prony's method** (1795). (To avoid the
common collision: this is *not* Distribution Matching Distillation.)

Honest, family-conditional pitch. We benchmarked both bases across two diffusion
families, and **no single basis wins**:

- On **flow-matching 3D generators** the exponential basis wins clearly and the lead
  grows with the cache interval (numbers below). This is the regime this calibrator is
  for.
- On **DiT-class denoising** (DiT-XL/2 ImageNet-256, 250-step DDPM) the ranking inverts:
  the sign-correct TaylorSeer polynomial is near-lossless (paired-noise FID drift 2.27 vs
  the uncached baseline at 3.81x), while the exponential basis drifts 1.7-1.9x more than
  even a near-reuse Hermite control at every interval tested. We therefore do **not**
  claim DMD as a better default; it is an additional basis for the workloads where it
  wins, default behavior unchanged.

The mechanism behind the 3D win: across denoising steps each cached feature stream
evolves under a slowly varying, near-linear operator; the exact solution class of a
linear feature-ODE is a sum of damped/oscillatory exponentials, and the exponential basis
is exact on that class where any polynomial diverges under extrapolation. Whether a given
model family's stream is in that class at the served horizons is empirical, hence the
per-family numbers below.

It plugs into the existing `CalibratorConfig` pattern, exactly like
`TaylorSeerCalibratorConfig`:

```python
import cache_dit
from cache_dit import DMDCalibratorConfig

cache_dit.enable_cache(
    pipe,
    calibrator_config=DMDCalibratorConfig(dmd_history=6),
)
```

The reference implementation
([hicache-plus-plus](https://github.com/Archerkattri/hicache-plus-plus)) also ships a
training-free holdout selector (`backend="auto"`) that backcasts a held-out snapshot with
both bases per compute window and serves the winner. We benchmarked it on this exact
split and report the honest verdict: it solves intra-run regime switches, but it does
not recover the family-level winner on DiT (both holdout modes served the exponential
arm there, FID drift 18.11 vs the corrected polynomial's 3.54), so the recommended way
to consume this calibrator is a **per-family default** (DMD for flow-matching
generators; TaylorSeer for DiT-class denoising), not a selector. This PR keeps the
surface minimal: one new basis.

## What the calibrator does (math summary)

At each full-compute step the calibrator records the computed tensor as a snapshot
(per named stream, like the TaylorSeer states). At an approximation step it:

1. takes the longest **uniformly spaced** suffix of the snapshot history (the identified
   propagator advances exactly one snapshot-spacing per application, and DBCache's dynamic
   decisions can make the compute cadence non-uniform; mixed spacings would corrupt the
   fit);
2. identifies the linear propagator `A` with `Y_{t+1} ~ A Y_t` via one economy SVD of the
   `[d, n]` snapshot matrix (`n` = history <= 6, so this is cheap relative to a forward
   pass) with spectrum-based rank truncation (this is what rejects noise);
3. eigendecomposes once per compute window (cached; refit only when a new snapshot
   arrives) and forecasts the (fractional) horizon `k` by eigenvalue powers:
   `Y_{t+k} ~ Phi (lambda^k * b)`, `b = pinv(Phi) Y_t`.

Below the 4-snapshot identifiability floor (a real-valued trajectory spends two real
degrees of freedom per complex pole, so one oscillatory mode already needs three snapshot
pairs), or whenever the fit is degenerate/non-finite, it transparently falls back to the
TaylorSeer expansion it also maintains; warm-up behaves exactly like the existing
calibrator.

## Changes

- `caching/cache_contexts/calibrators/dmd.py`: new `DMDCalibrator` + `DMDState`,
  mirroring the `TaylorSeerCalibrator` / `TaylorSeerState` API (`mark_step_begin`,
  `update`, `approximate`, `step`, `reset_cache`; per-stream states keyed by name).
- `caching/cache_contexts/calibrators/__init__.py`: new `DMDCalibratorConfig`
  dataclass (`dmd_history`, `dmd_rank`, `dmd_ridge`), registered in the `Calibrator`
  factory and `_supported_calibrators`.
- Export chain: `DMDCalibratorConfig` re-exported from `cache_contexts`, `caching`, and
  the top-level `cache_dit` namespace, alongside `TaylorSeerCalibratorConfig`.

No new dependencies (torch-only), no behavior change unless `calibrator_type="dmd"` is
selected.

## Validation so far

- Unit-level: on synthetic trajectories from the exponential solution class, the
  calibrator's post-warm-up forecast error is ~5e-8 relative L2 where the order-1 Taylor
  expansion sits at ~0.4-1.9 (same snapshots, same schedule).
- Method-level (reference implementation,
  [hicache-plus-plus](https://github.com/Archerkattri/hicache-plus-plus)), flow-matching
  3D generators: on Hunyuan3D-2.1 (Toys4K, F-score@0.05 vs uncached baseline 0.911) the
  deployed polynomial arm decays 0.88 / 0.74 / 0.38 at cache interval 3 / 5 / 6 while the
  exponential basis holds 0.85 / 0.86 / 0.62; exactly lossless at interval 5 on
  Hunyuan3D-2-mini; on SAM3D geometry-lossless (F1 = 1.000) through interval 6 at 1.56x.
- DiT-class denoising, reported for honesty (the regime where you should NOT pick this
  calibrator). DiT-XL/2 ImageNet-256, 250-step DDPM, cfg 1.5, paired-noise FID-10k drift
  vs the uncached baseline (lossless cache reads ~0; full ledger and protocol:
  `hicache-plus-plus/benchmarks/dit_imagenet/RESULTS_DIT.md`):

  | basis | i4 | i6 | i8 |
  |---|---:|---:|---:|
  | TaylorSeer (corrected, +k) | **2.27** (3.81x) | - | - |
  | Hermite (corrected, +k) | 3.54 (3.79x) | **6.46** (5.46x) | **10.74** (7.21x) |
  | exponential (DMD) | 18.02 | 54.24 | 100.65 |

  Holdout selection does not rescue DiT either: in our pre-registered A/B both holdout
  modes of the reference selector served the exponential arm (drift 18.11), because the
  richer exponential fit backcasts the snapshot history better even where it
  extrapolates forward worse. Hence the per-family default recommendation above.
- Remaining before marking ready for review: a FLUX.1-dev A/B with this exact
  calibrator.

Scoping summary for reviewers: this adds an opt-in basis that wins on flow-matching
generators and is reported, with numbers, as losing on DiT-class denoising. The
per-interval tables are included so the trade-off is judged directly, not from a single
operating point.
