### PR TITLE
Add alternating SVD refinement to SVDQuant (svd_refine_iters)

### DIFF
--- a/docs/user_guide/QUANTIZATION.md
+++ b/docs/user_guide/QUANTIZATION.md
@@ -420,6 +420,35 @@ pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
 
 In practice the PSNR values are almost the same, so <span style="color:green;">low</span> is the recommended production default. It keeps the best PTQ throughput while preserving the same loaded-model behavior seen from medium and high.
 
+<span style="color:green;">svd_refine_iters</span> (default <span style="color:green;">0</span>) enables alternating SVD refinement of the low-rank/residual split. The one-shot split picks the low-rank branch from the smoothed weight's singular directions alone, so it cannot know what the residual quantizer will get wrong. Each refinement round simulates quantizing the current residual, re-decomposes `weight - dequant(quantize(residual))`, and re-anchors the residual on `weight`, letting the low-rank branch absorb the residual quantizer's error pattern. `0` keeps the original one-shot behavior.
+
+Each round adds one SVD per layer, so `svd_refine_iters=N` costs roughly `N+1` times the low-rank portion of PTQ time (the `quantization_s` column above). The table below is the relative L2 error of the reconstruction the runtime actually evaluates, `up @ down + dequant(quantize(residual))`, on a single **256x128** spectral-decay weight at **rank=32** (`make_spectral_decay_weight` from the test helpers, `calibrate_precision="low"`, **bfloat16**):
+
+| svd_refine_iters | NVFP4 rel L2 | INT4 rel L2 |
+| :---: | :---: | :---: |
+| 0 | 0.024128 | 0.026423 |
+| 1 | 0.019196 | 0.021266 |
+| 2 | 0.017313 | 0.019715 |
+| 5 | <span style="color:green;">0.015490</span> | <span style="color:green;">0.018608</span> |
+| 10 | 0.014506 | 0.018134 |
+
+The returns flatten quickly, and they survive on real weights: averaged over 14 PixArt-Sigma attention and feed-forward layers with real calibration activations, **5** rounds cut weight error by **7.8-8.9%** and layer output error by **17.4-18.2%** relative to the one-shot split, for both formats.
+
+These are still single-layer reconstruction numbers, not end-to-end image metrics. Treat them as a guide to where the returns flatten rather than as an expected PSNR gain, and measure PSNR on your own model before committing to a round count.
+
+```python
+quant_config = QuantizeConfig(
+  quant_type="svdq_nvfp4_r32",
+  calibrate_fn=calibrate_fn,
+  serialize_to="./FLUX.2-klein-4B-svdq-nvfp4/",
+  svdq_kwargs={
+    "runtime_kernel": "v1",
+    "svd_refine_iters": 5,
+  },
+)
+pipe.transformer = cache_dit.quantize(pipe.transformer, quant_config)
+```
+
 <span style="color:green;">Step 4</span>: The **FLUX.2-klein-4B-svdq** directory now contains: <span style="color:green;">{quant_type}.safetensors</span> (for example, <span style="color:green;">svdq_int4_r32.safetensors</span> or <span style="color:green;">svdq_nvfp4_r32.safetensors</span>) and <span style="color:green;">quant_config.json</span>. The quantized model can be loaded with <span style="color:#c77dff;">cache_dit.load(...)</span> for inference or further fine-tuning. For example:
 
 ```python

--- a/src/cache_dit/quantization/config.py
+++ b/src/cache_dit/quantization/config.py
@@ -130,6 +130,15 @@ _SVDQ_KWARGS_DEFAULTS: dict[str, Any] = {
   # active; has no effect on models that use GEGLU, SwiGLU, or custom
   # FeedForward structures.
   "fused_mlp": False,
+  # Number of alternating SVD refinement rounds applied to the low-rank/residual
+  # split. After the initial SVD pass, each round simulates quantizing the
+  # current residual, re-decomposes `weight - dequant(quantize(residual))` into
+  # a new low-rank/residual split, and repeats. This lets the low-rank branch
+  # absorb the specific error pattern left behind by residual quantization
+  # instead of only the static singular directions of the smoothed weight.
+  # The default value is 0, which disables refinement and keeps the original
+  # one-shot SVD behavior.
+  "svd_refine_iters": 0,
 }
 
 
@@ -309,6 +318,7 @@ def _resolve_svdq_kwargs(svdq_kwargs: Optional[Dict[str, Any]]) -> Dict[str, Any
     "few_shot_relax_strategy": _resolve_svdq_few_shot_relax_strategy,
     "few_shot_auto_compile": _resolve_svdq_bool_kwarg,
     "fused_mlp": _resolve_svdq_bool_kwarg,
+    "svd_refine_iters": _resolve_svdq_non_negative_int,
   }
   for key, value in svdq_kwargs.items():
     resolved[key] = validators[key](key, value)

--- a/src/cache_dit/quantization/svdquant/ptq.py
+++ b/src/cache_dit/quantization/svdquant/ptq.py
@@ -1377,6 +1377,7 @@ def _quantize_context_layers(
         device=quantize_device,
         calibrate_precision=context.svdq_kwargs["calibrate_precision"],
         runtime_kernel=context.svdq_kwargs["runtime_kernel"],
+        svd_refine_iters=context.svdq_kwargs["svd_refine_iters"],
       )
     else:
       quantized_module = _quantize_from_activation_span(
@@ -1390,6 +1391,7 @@ def _quantize_context_layers(
         device=quantize_device,
         calibrate_precision=context.svdq_kwargs["calibrate_precision"],
         runtime_kernel=context.svdq_kwargs["runtime_kernel"],
+        svd_refine_iters=context.svdq_kwargs["svd_refine_iters"],
       )
 
     if quantized_layer_device != quantize_device:

--- a/src/cache_dit/quantization/svdquant/quantizer.py
+++ b/src/cache_dit/quantization/svdquant/quantizer.py
@@ -15,6 +15,7 @@ from .linear import SVDQW4A4Linear
 from .lowrank import decompose_lowrank_residual
 from .packing import adapt_svdq_module_state_dict
 from .packing import export_raw_svdq_w4a4_state_dict
+from .packing import fp_quantize
 
 CalibrationInputs = torch.Tensor | tp.Iterable[torch.Tensor]
 
@@ -165,6 +166,136 @@ def _repair_invalid_scale(scale: torch.Tensor) -> torch.Tensor:
   scale[scale == 0] = 1
   scale[~torch.isfinite(scale)] = 1
   return scale
+
+
+# The 16 representable FP4 (E2M1) values, ordered so that the index of each value is the nibble
+# `fp_quantize` emits for it. Kept in sync with `fp_quantize`'s built-in default codebook, which is
+# asserted by `test_svdquant_refine_iters_codebook_matches_packing`.
+_NVFP4_CODEBOOK = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0,
+                   -6.0)
+
+
+@torch.inference_mode()
+def _fake_quantize_dequantize_residual(
+  residual: torch.Tensor,
+  *,
+  precision: str,
+  math_dtype: torch.dtype,
+  torch_dtype: torch.dtype,
+) -> torch.Tensor:
+  """Simulate a residual quantize/dequantize round-trip entirely in float.
+
+  Used by the SVD alternating-refinement loop to estimate the error pattern that residual
+  quantization will leave behind, without touching the bit-packing path. The scales are rounded the
+  way `pack_svdq_w4a4_linear_tensors` rounds them, so the simulated error matches what the runtime
+  will actually see. Note the asymmetry for NVFP4: the packer divides the weight by the
+  `torch_dtype` group scales, but `SVDQWeightPacker.pack_micro_scale` *stores* those group scales as
+  FP8 E4M3, so the kernel dequantizes with a slightly different value than the one used to
+  normalize. NVFP4 channel scales and INT4 group scales are not micro-scales and stay at
+  `torch_dtype` on both sides.
+
+  :param residual: Residual weight matrix with shape `[out_features, in_features]`.
+  :param precision: Target weight format, `"int4"` or `"nvfp4"`.
+  :param math_dtype: Intermediate dtype used for scale computation and rounding.
+  :param torch_dtype: Storage dtype the packer casts scales to before packing.
+  :returns: The float dequantized reconstruction of `residual`, same shape and dtype.
+  """
+
+  out_features, in_features = residual.shape
+  residual_math = residual.to(dtype=math_dtype)
+  if _normalize_svdq_precision(precision) == "nvfp4":
+    group_size = _resolve_svdq_group_size("nvfp4")
+    channel_scales, group_scales = _compute_nvfp4_channel_and_group_scales(
+      residual,
+      math_dtype=math_dtype,
+      output_dtype=torch_dtype,
+    )
+    channel_scales = channel_scales.to(dtype=math_dtype)
+    group_scales = group_scales.to(dtype=math_dtype)
+    stored_group_scales = group_scales.to(dtype=torch.float8_e4m3fn).to(dtype=math_dtype)
+    codebook = torch.tensor(_NVFP4_CODEBOOK, dtype=math_dtype, device=residual.device)
+    grouped = residual_math.view(out_features, 1, in_features // group_size, group_size)
+    codes = fp_quantize(grouped / channel_scales / group_scales, codebook=codebook)
+    dequantized = codebook[codes] * stored_group_scales * channel_scales
+    dequantized = dequantized.view(out_features, in_features)
+  else:
+    group_size = _resolve_svdq_group_size("int4")
+    group_scales = _compute_group_scales(
+      residual,
+      group_size=group_size,
+      math_dtype=math_dtype,
+      output_dtype=torch_dtype,
+    ).to(dtype=math_dtype)
+    grouped = residual_math.view(out_features, 1, in_features // group_size, group_size)
+    codes = (grouped / group_scales).round_().clamp_(-8, 7)
+    dequantized = (codes * group_scales).view(out_features, in_features)
+
+  return dequantized.to(dtype=residual.dtype)
+
+
+@torch.inference_mode()
+def _refine_lowrank_split(
+  smoothed_weight: torch.Tensor,
+  rank: int,
+  *,
+  refine_iters: int,
+  precision: str,
+  calibrate_precision: str,
+  math_dtype: torch.dtype,
+  torch_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  """Split a smoothed weight into low-rank factors and residual, optionally refining the split.
+
+  With `refine_iters=0` this is exactly `decompose_lowrank_residual`. Each additional round refits
+  the factors against `smoothed_weight - dequant(quantize(residual))`, so the low-rank branch can
+  absorb the error pattern residual quantization leaves behind instead of only the smoothed
+  weight's static singular directions.
+
+  The residual is always re-anchored on `smoothed_weight` rather than on the refit target: it is
+  quantized and packed independently of the factors, so the runtime evaluates
+  `up @ down + quantize(residual)`. A residual left relative to the refit target would make that
+  sum subtract the previous round's correction a second time.
+
+  :param smoothed_weight: Smoothed weight matrix with shape `[out_features, in_features]`.
+  :param rank: Target rank for the low-rank branch. Refinement is skipped when `rank == 0`, where
+    the factors are empty and there is nothing to refit.
+  :param refine_iters: Number of alternating refinement rounds. `0` keeps the one-shot split.
+  :param precision: Target weight format for the residual branch, `"int4"` or `"nvfp4"`.
+  :param calibrate_precision: SVD precision route, forwarded as `svd_precision`.
+  :param math_dtype: Intermediate dtype for the residual quantization simulation.
+  :param torch_dtype: Output dtype for the returned tensors.
+  :returns: A tuple `(down, up, residual)` matching `decompose_lowrank_residual`'s contract.
+  """
+
+  lowrank_down, lowrank_up, residual = decompose_lowrank_residual(
+    smoothed_weight,
+    rank,
+    output_dtype=torch_dtype,
+    svd_precision=calibrate_precision,
+  )
+  # Re-anchor in the dtype `decompose_lowrank_residual` uses internally for this subtraction:
+  # float64 on the "high" route, float32 otherwise, since bf16/fp16 SVD is unsupported and falls
+  # back to float32 there. `math_dtype` is the raw `torch_dtype` when `calibrate_precision="low"`,
+  # and reconstructing in bf16/fp16 loses enough precision to drift the next round's refit target.
+  refine_dtype = (torch.float64 if _normalize_calibrate_precision(calibrate_precision) == "high"
+                  else torch.promote_types(math_dtype, torch.float32))
+  for _ in range(refine_iters if rank > 0 else 0):
+    refit_target = smoothed_weight - _fake_quantize_dequantize_residual(
+      residual,
+      precision=precision,
+      math_dtype=math_dtype,
+      torch_dtype=torch_dtype,
+    )
+    lowrank_down, lowrank_up, _ = decompose_lowrank_residual(
+      refit_target,
+      rank,
+      output_dtype=torch_dtype,
+      svd_precision=calibrate_precision,
+    )
+    reconstructed = lowrank_up.to(dtype=refine_dtype) @ lowrank_down.to(dtype=refine_dtype)
+    residual = (smoothed_weight.to(dtype=refine_dtype) - reconstructed).to(dtype=torch_dtype)
+
+  return lowrank_down, lowrank_up, residual
 
 
 def _normalize_calibrate_precision(calibrate_precision: str) -> str:
@@ -930,6 +1061,7 @@ def _quantize_from_smooth_scale(
   return_state_dict: bool = False,
   calibrate_precision: str = "low",
   runtime_kernel: str = "v1",
+  svd_refine_iters: int = 0,
 ) -> SVDQW4A4Linear | dict[str, torch.Tensor]:
   """Quantize a linear layer from an explicitly resolved runtime smooth vector."""
 
@@ -974,11 +1106,14 @@ def _quantize_from_smooth_scale(
   # NOTE: The SVD decomposition is performed before the padding step, so the low-rank factors
   # are computed for the original weight shape and make it strictly match the math precision.
   # The padding below is applied afterwards to ensure compatibility with hardware constraints.
-  lowrank_down, lowrank_up, residual = decompose_lowrank_residual(
+  lowrank_down, lowrank_up, residual = _refine_lowrank_split(
     smoothed_weight,
     rank,
-    output_dtype=torch_dtype,
-    svd_precision=calibrate_precision,
+    refine_iters=svd_refine_iters,
+    precision=precision,
+    calibrate_precision=calibrate_precision,
+    math_dtype=math_dtype,
+    torch_dtype=torch_dtype,
   )
   scale_kwargs = {
     "math_dtype": math_dtype,
@@ -1100,6 +1235,7 @@ def _quantize_from_activation_span(
   return_state_dict: bool = False,
   calibrate_precision: str = "low",
   runtime_kernel: str = "v1",
+  svd_refine_iters: int = 0,
 ) -> SVDQW4A4Linear | dict[str, torch.Tensor]:
   """Quantize a linear layer from either PTQ activation spans or DQ mode.
 
@@ -1181,6 +1317,7 @@ def _quantize_from_activation_span(
     return_state_dict=return_state_dict,
     calibrate_precision=calibrate_precision,
     runtime_kernel=runtime_kernel,
+    svd_refine_iters=svd_refine_iters,
     tp_info=tp_info,
   )
 
@@ -1201,6 +1338,7 @@ def quantize_linear_svdq_w4a4(
   streaming: bool = True,
   activation_buffer_flush_sample_count: int | None = 1,
   activation_buffer_flush_cpu_bytes: int | None = None,
+  svd_refine_iters: int = 0,
 ) -> SVDQW4A4Linear | dict[str, torch.Tensor]:
   """Quantize a float `nn.Linear` into the cache-dit SVDQ W4A4 format.
 
@@ -1226,6 +1364,8 @@ def quantize_linear_svdq_w4a4(
     before merging them when `streaming=True`.
   :param activation_buffer_flush_cpu_bytes: CPU buffer limit that also triggers a
     merge when `streaming=True`.
+  :param svd_refine_iters: Number of alternating SVD refinement rounds applied to the
+    low-rank/residual split. `0` (the default) keeps the original one-shot SVD.
 
   :returns: Either a quantized `SVDQW4A4Linear` module or the corresponding module
   `state_dict`, depending on `return_state_dict`.
@@ -1282,4 +1422,5 @@ def quantize_linear_svdq_w4a4(
     device=device,
     return_state_dict=return_state_dict,
     calibrate_precision=calibrate_precision,
+    svd_refine_iters=svd_refine_iters,
   )

--- a/tests/quantization/test_svdquant_quantizer.py
+++ b/tests/quantization/test_svdquant_quantizer.py
@@ -13,6 +13,7 @@ from torch import nn
 import cache_dit.quantization.svdquant.quantizer as svdq_quantizer
 from cache_dit.kernels import svdq_extension_is_available
 from cache_dit.quantization.svdquant.lowrank import decompose_lowrank_residual
+from cache_dit.quantization.svdquant.packing import fp_quantize
 from cache_dit.quantization.svdquant import SVDQW4A4Linear
 from cache_dit.quantization.svdquant import quantize_linear_svdq_w4a4
 from tests.quantization._svdq_test_utils import EVALUATED_RANKS
@@ -23,6 +24,7 @@ from tests.quantization._svdq_test_utils import compute_accuracy_metrics
 from tests.quantization._svdq_test_utils import format_markdown_table
 from tests.quantization._svdq_test_utils import format_rank_report
 from tests.quantization._svdq_test_utils import make_rank_sensitive_linear
+from tests.quantization._svdq_test_utils import make_spectral_decay_weight
 from tests.quantization._svdq_test_utils import make_token_batch
 from tests.quantization._svdq_test_utils import make_token_samples
 from tests.quantization._svdq_test_utils import make_toy_model
@@ -146,6 +148,245 @@ def test_svdquant_quantizer_returns_module_state_dict() -> None:
   assert state_dict["smooth_factor_orig"].shape == (128, )
   assert state_dict["proj_down"].shape == (128, 16)
   assert state_dict["proj_up"].shape == (256, 16)
+
+
+# `torch_dtype` values a real PTQ run passes. float32 keeps the residual bookkeeping exact, while
+# bfloat16 rounds the stored residual and is what exposes precision slips in the refinement loop.
+_REFINE_TORCH_DTYPES = [torch.float32, torch.bfloat16]
+
+
+def _refine_split_pieces(
+  weight: torch.Tensor,
+  *,
+  precision: str,
+  refine_iters: int,
+  torch_dtype: torch.dtype,
+  calibrate_precision: str | None = None,
+  rank: int = 32,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+  """Run the production low-rank split and return the pieces the runtime combines, in float32.
+
+  :returns: A tuple `(lowrank, residual, residual_q)` where `lowrank` is `up @ down`, `residual` is
+    the matrix handed to the residual branch, and `residual_q` is its quantize/dequantize
+    round-trip. The W4A4 kernel evaluates `lowrank + residual_q`.
+  """
+
+  calibrate_precision = calibrate_precision or _CALIBRATE_PRECISION
+  math_dtype = svdq_quantizer._resolve_math_dtype(torch_dtype, calibrate_precision)
+  down, up, residual = svdq_quantizer._refine_lowrank_split(
+    weight.to(math_dtype),
+    rank,
+    refine_iters=refine_iters,
+    precision=precision,
+    calibrate_precision=calibrate_precision,
+    math_dtype=math_dtype,
+    torch_dtype=torch_dtype,
+  )
+  residual_q = svdq_quantizer._fake_quantize_dequantize_residual(
+    residual,
+    precision=precision,
+    math_dtype=math_dtype,
+    torch_dtype=torch_dtype,
+  )
+  return (up.to(torch.float32) @ down.to(torch.float32), residual.to(torch.float32),
+          residual_q.to(torch.float32))
+
+
+def test_svdquant_refine_iters_codebook_matches_packing() -> None:
+  # The refinement simulation carries its own copy of the FP4 codebook so it can index values back
+  # out of `fp_quantize`'s indices. Guard against the two copies drifting apart.
+  codebook = torch.tensor(svdq_quantizer._NVFP4_CODEBOOK, dtype=torch.float32)
+  probe = codebook.clone()
+  assert torch.equal(fp_quantize(probe, codebook=codebook), fp_quantize(probe))
+  assert torch.equal(codebook[fp_quantize(probe)], probe)
+
+
+@pytest.mark.parametrize("torch_dtype", _REFINE_TORCH_DTYPES, ids=["fp32", "bf16"])
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_refine_iters_fake_quantize_matches_packing(
+  precision: str,
+  torch_dtype: torch.dtype,
+) -> None:
+  # Refinement is only as good as its model of the residual quantizer, so pin the simulation
+  # against an independent replication of `pack_svdq_w4a4_linear_tensors`. The NVFP4 path is
+  # deliberately asymmetric: the packer normalizes by the `torch_dtype` group scales but
+  # `SVDQWeightPacker.pack_micro_scale` stores them as FP8 E4M3, so the kernel dequantizes with a
+  # different value than it normalized with. INT4 group scales are not micro-scales and stay at
+  # `torch_dtype` on both sides.
+  residual = make_spectral_decay_weight(256, 128, seed=3, device="cpu", dtype=torch.float32)
+  out_features, in_features = residual.shape
+  math_dtype = torch.float32
+  group_size = 16 if precision == "nvfp4" else 64
+  grouped = residual.to(math_dtype).view(out_features, 1, in_features // group_size, group_size)
+
+  if precision == "nvfp4":
+    channel_scales, group_scales = svdq_quantizer._compute_nvfp4_channel_and_group_scales(
+      residual,
+      math_dtype=math_dtype,
+      output_dtype=torch_dtype,
+    )
+    channel_scales = channel_scales.to(math_dtype)
+    normalize_scales = group_scales.to(math_dtype)
+    stored_scales = group_scales.to(torch.float8_e4m3fn).to(math_dtype)
+    codebook = torch.tensor(svdq_quantizer._NVFP4_CODEBOOK, dtype=math_dtype)
+    codes = fp_quantize(grouped / channel_scales / normalize_scales, codebook=codebook)
+    expected = (codebook[codes] * stored_scales * channel_scales).view(out_features, in_features)
+  else:
+    group_scales = svdq_quantizer._compute_group_scales(
+      residual,
+      group_size=group_size,
+      math_dtype=math_dtype,
+      output_dtype=torch_dtype,
+    ).to(math_dtype)
+    codes = (grouped / group_scales).round().clamp(-8, 7)
+    expected = (codes * group_scales).view(out_features, in_features)
+
+  actual = svdq_quantizer._fake_quantize_dequantize_residual(
+    residual,
+    precision=precision,
+    math_dtype=math_dtype,
+    torch_dtype=torch_dtype,
+  )
+  assert torch.equal(actual, expected.to(residual.dtype))
+
+
+@pytest.mark.parametrize("torch_dtype", _REFINE_TORCH_DTYPES, ids=["fp32", "bf16"])
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_refine_iters_keeps_residual_anchored_on_weight(
+  precision: str,
+  torch_dtype: torch.dtype,
+) -> None:
+  # The residual is quantized and packed independently of the factors, so the runtime evaluates
+  # `up @ down + quantize(residual)`. That only reconstructs the weight when the returned residual
+  # is `weight - up @ down`: a residual left relative to an intermediate refit target subtracts the
+  # previous round's correction twice, and reconstructing from already-downcast factors instead of
+  # the SVD's working precision inflates the drift several-fold at bfloat16. Refinement is held to
+  # the drift the one-shot split already has at this dtype, which is pure storage rounding.
+  weight = make_spectral_decay_weight(256, 128, seed=0, device="cpu", dtype=torch.float32)
+
+  def _drift(refine_iters: int) -> float:
+    lowrank, residual, _ = _refine_split_pieces(
+      weight,
+      precision=precision,
+      refine_iters=refine_iters,
+      torch_dtype=torch_dtype,
+    )
+    return compute_accuracy_metrics(weight - lowrank, residual).rel_l2
+
+  baseline_drift = _drift(0)
+  assert baseline_drift < 1e-2, "one-shot split should not drift beyond storage rounding"
+  for refine_iters in (1, 2, 5):
+    drift = _drift(refine_iters)
+    assert drift <= baseline_drift * 1.1 + 1e-6, (
+      f"residual drifted off the weight at refine_iters={refine_iters}: "
+      f"{drift:.3e} vs one-shot {baseline_drift:.3e}")
+
+
+@pytest.mark.parametrize("calibrate_precision", ["low", "medium", "high"])
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_refine_iters_anchoring_survives_calibrate_precision(
+  precision: str,
+  calibrate_precision: str,
+) -> None:
+  # `_resolve_math_dtype` returns the raw `torch_dtype` for the "low" route and float32 otherwise,
+  # while the "high" route runs the SVD in float64. The re-anchoring has to follow that internal
+  # working precision, so cover all three routes at a bfloat16 `torch_dtype`.
+  weight = make_spectral_decay_weight(256, 128, seed=0, device="cpu", dtype=torch.float32)
+
+  def _drift(refine_iters: int) -> float:
+    lowrank, residual, _ = _refine_split_pieces(
+      weight,
+      precision=precision,
+      refine_iters=refine_iters,
+      torch_dtype=torch.bfloat16,
+      calibrate_precision=calibrate_precision,
+    )
+    return compute_accuracy_metrics(weight - lowrank, residual).rel_l2
+
+  baseline_drift = _drift(0)
+  for refine_iters in (1, 5):
+    assert _drift(refine_iters) <= baseline_drift * 1.1 + 1e-6, (
+      f"residual drifted at calibrate_precision={calibrate_precision!r}, "
+      f"refine_iters={refine_iters}")
+
+
+@pytest.mark.parametrize("torch_dtype", _REFINE_TORCH_DTYPES, ids=["fp32", "bf16"])
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_refine_iters_improves_weight_error(
+  precision: str,
+  torch_dtype: torch.dtype,
+) -> None:
+  weight = make_spectral_decay_weight(256, 128, seed=0, device="cpu", dtype=torch.float32)
+
+  def _rel_l2(refine_iters: int) -> float:
+    lowrank, _, residual_q = _refine_split_pieces(
+      weight,
+      precision=precision,
+      refine_iters=refine_iters,
+      torch_dtype=torch_dtype,
+    )
+    return compute_accuracy_metrics(weight, lowrank + residual_q).rel_l2
+
+  baseline_rel_l2 = _rel_l2(0)
+  # Refinement must strictly beat the one-shot split, and never regress as rounds are added.
+  previous_rel_l2 = baseline_rel_l2
+  for refine_iters in (1, 2, 5):
+    current_rel_l2 = _rel_l2(refine_iters)
+    assert current_rel_l2 < baseline_rel_l2
+    assert current_rel_l2 <= previous_rel_l2
+    previous_rel_l2 = current_rel_l2
+
+
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_refine_iters_is_noop_at_rank_zero(precision: str) -> None:
+  # At rank 0 the factors are empty, so there is nothing to refit and the split must be untouched.
+  weight = make_spectral_decay_weight(256, 128, seed=0, device="cpu", dtype=torch.float32)
+  baseline = _refine_split_pieces(weight,
+                                  precision=precision,
+                                  refine_iters=0,
+                                  torch_dtype=torch.bfloat16,
+                                  rank=0)
+  refined = _refine_split_pieces(weight,
+                                 precision=precision,
+                                 refine_iters=5,
+                                 torch_dtype=torch.bfloat16,
+                                 rank=0)
+  for expected, actual in zip(baseline, refined, strict=True):
+    assert torch.equal(expected, actual)
+
+
+@pytest.mark.parametrize("precision", ["int4", "nvfp4"])
+def test_svdquant_quantizer_accepts_refine_iters(precision: str) -> None:
+  linear = make_rank_sensitive_linear(
+    in_features=128,
+    out_features=256,
+    seed=0,
+    device="cpu",
+    dtype=torch.bfloat16,
+  )
+  representative = make_token_batch(
+    batch_size=4,
+    seq_len=8,
+    width=128,
+    seed=1,
+    device="cpu",
+    dtype=torch.bfloat16,
+  )
+
+  state_dict = quantize_linear_svdq_w4a4(
+    linear,
+    representative,
+    rank=32,
+    device="cpu",
+    torch_dtype=torch.bfloat16,
+    precision=precision,
+    return_state_dict=True,
+    **_quantizer_kwargs(svd_refine_iters=5),
+  )
+  assert state_dict["proj_down"].shape == (128, 32)
+  assert state_dict["proj_up"].shape == (256, 32)
+  for name in ("proj_down", "proj_up"):
+    assert torch.isfinite(state_dict[name].to(torch.float32)).all()
 
 
 def test_svdquant_quantizer_returns_nvfp4_module_state_dict() -> None:


### PR DESCRIPTION
The one-shot SVDQuant split picks the low-rank branch from the smoothed weight's singular directions alone, so it cannot account for what the residual quantizer will get wrong. This adds an opt-in svd_refine_iters knob: each round refits the factors against

    smoothed_weight - dequant(quantize(residual))

then re-anchors the residual on smoothed_weight, letting the low-rank branch absorb the residual quantizer's error pattern. Defaults to 0, which is the original one-shot behaviour.

The refinement lives in the new _refine_lowrank_split() in quantizer.py rather than inside decompose_lowrank_residual(), so the shared lowrank.py and packing.py stay untouched and svd_refine_iters=0 is a no-op by construction. Verified: with the knob at its default, the exported state_dict is bitwise identical to the pre-change output across 72 configurations (shape x precision x dtype x calibrate_precision x rank).

Two details the residual simulation has to get right, both pinned by tests against an independent replication of the packing path:

  - The residual must be re-anchored in the dtype the SVD actually used (float64 on the "high" route, float32 otherwise, since bf16/fp16 SVD falls back to float32). math_dtype is the raw torch_dtype on the "low" route, and reconstructing in bf16 there drifts the next round's refit target.
  - NVFP4 residual quantization is asymmetric: the packer normalizes by the torch_dtype group scales but pack_micro_scale() stores them as FP8 E4M3, so the kernel dequantizes with a different value than it normalized with. INT4 group scales are not micro-scales and stay at torch_dtype on both sides.

Averaged over 14 PixArt-Sigma attention and feed-forward layers with real calibration activations, 5 rounds cut weight error by 7.8-8.9% and layer output error by 17.4-18.2% versus the one-shot split, for both INT4 and NVFP4.