### PR TITLE
Fix _is_cached class/instance mismatch for multi-transformer pipelines

### DIFF
--- a/src/cache_dit/caching/cache_adapters/cache_adapter.py
+++ b/src/cache_dit/caching/cache_adapters/cache_adapter.py
@@ -172,8 +172,9 @@ class CachedAdapter:
     # `_context_manager` -- causing this method to return early and a later
     # `assert hasattr(block_adapter.pipe, "_context_manager")` to fail. Only skip when
     # this specific instance actually has a context manager.
-    if BlockAdapter.is_cached(block_adapter.pipe) and hasattr(
-        block_adapter.pipe, "_context_manager"
+    if BlockAdapter.is_cached(block_adapter.pipe) and isinstance(
+        getattr(block_adapter.pipe, "_context_manager", None),
+        ContextManager._supported_managers,
     ):
       logger.warning("Pipeline has been already cached, skip creating cache context again.")
       return None, block_adapter.pipe

--- a/src/cache_dit/caching/cache_adapters/cache_adapter.py
+++ b/src/cache_dit/caching/cache_adapters/cache_adapter.py
@@ -162,7 +162,19 @@ class CachedAdapter:
 
     BlockAdapter.assert_normalized(block_adapter)
 
-    if BlockAdapter.is_cached(block_adapter.pipe):
+    # `_is_cached` is set on `block_adapter.pipe.__class__` further down in this
+    # method, while `_context_manager` is set on the instance. Pipelines that wrap
+    # more than one transformer in a shared placeholder class (e.g. FakeDiffusionPipeline
+    # for dual/multi-DiT models) create a fresh pipe instance per transformer, but all
+    # those instances share the same class. Once the first instance sets the class-level
+    # `_is_cached` flag, `BlockAdapter.is_cached()` (a plain `getattr`) reports every
+    # sibling instance as already cached too, even though they never got their own
+    # `_context_manager` -- causing this method to return early and a later
+    # `assert hasattr(block_adapter.pipe, "_context_manager")` to fail. Only skip when
+    # this specific instance actually has a context manager.
+    if BlockAdapter.is_cached(block_adapter.pipe) and hasattr(
+        block_adapter.pipe, "_context_manager"
+    ):
       logger.warning("Pipeline has been already cached, skip creating cache context again.")
       return None, block_adapter.pipe
 

--- a/tests/api/test_multi_transformer_is_cached.py
+++ b/tests/api/test_multi_transformer_is_cached.py
@@ -1,0 +1,61 @@
+"""Regression test for the class-vs-instance `_is_cached` bug.
+
+`CachedAdapter.create_context` sets `_is_cached` on `block_adapter.pipe.__class__`
+but `_context_manager` on the instance. Transformer-only usage (no real pipeline)
+wraps each transformer in its own `FakeDiffusionPipeline()` instance, but all such
+instances share one class -- exactly what happens for multi-DiT pipelines like
+MiniMax-H3, which build one BlockAdapter per DiT module. Enabling cache on a second
+transformer used to see the first transformer's class-level `_is_cached` flag and
+skip creating its own context manager, crashing with an AttributeError.
+"""
+import gc
+
+import cache_dit
+from cache_dit import BlockAdapter, DBCacheConfig, ForwardPattern
+from utils import RandTransformer2DModel_Pattern_0_1_2
+
+
+def test_enable_cache_on_two_independent_transformers():
+  gc.collect()
+
+  transformer_a = RandTransformer2DModel_Pattern_0_1_2(pattern=ForwardPattern.Pattern_0)
+  transformer_b = RandTransformer2DModel_Pattern_0_1_2(pattern=ForwardPattern.Pattern_0)
+
+  adapter_a = cache_dit.enable_cache(
+    BlockAdapter(
+      transformer=transformer_a,
+      blocks=transformer_a.transformer_blocks,
+      forward_pattern=ForwardPattern.Pattern_0,
+    ),
+    cache_config=DBCacheConfig(
+      Fn_compute_blocks=1,
+      Bn_compute_blocks=0,
+      residual_diff_threshold=0.05,
+    ),
+  )
+
+  # Second, independent transformer: its BlockAdapter gets its own fresh
+  # FakeDiffusionPipeline() instance, but that instance shares a class with
+  # transformer_a's. This used to crash with:
+  #   AttributeError: 'FakeDiffusionPipeline' object has no attribute '_context_manager'
+  adapter_b = cache_dit.enable_cache(
+    BlockAdapter(
+      transformer=transformer_b,
+      blocks=transformer_b.transformer_blocks,
+      forward_pattern=ForwardPattern.Pattern_0,
+    ),
+    cache_config=DBCacheConfig(
+      Fn_compute_blocks=1,
+      Bn_compute_blocks=0,
+      residual_diff_threshold=0.05,
+    ),
+  )
+
+  assert hasattr(transformer_b, "_context_manager")
+  assert transformer_a._context_manager is not transformer_b._context_manager
+
+  cache_dit.disable_cache(adapter_a)
+  cache_dit.disable_cache(adapter_b)
+
+  del transformer_a, transformer_b, adapter_a, adapter_b
+  gc.collect()


### PR DESCRIPTION
## Summary

`CachedAdapter.create_context()` sets `_is_cached` on `block_adapter.pipe.__class__`,
but sets `_context_manager` on the instance:

```python
block_adapter.pipe._context_manager = context_manager       # instance level
...
block_adapter.pipe.__class__._is_cached = True               # class level
```

For pipelines with more than one transformer that don't have a real `pipe` object
(a `BlockAdapter(transformer=..., ...)` call per transformer, as one would do for a
dual/multi-DiT model), each transformer gets wrapped in its own fresh
`FakeDiffusionPipeline()` instance -- but all of those instances share the *same*
class. Once the first transformer's setup flips the class-level `_is_cached` flag,
`BlockAdapter.is_cached()` -- ultimately a plain `getattr(pipe, "_is_cached", False)`,
which can't distinguish an instance attribute from an inherited class attribute --
reports every sibling instance as already cached too, even though it never got its
own `_context_manager`. `create_context()` then returns early, and the caller's
`assert hasattr(block_adapter.pipe, "_context_manager")` fails for the second
transformer.

Fix: only take the early-return/skip path when *this* pipe instance actually already
carries its own `_context_manager`.

## Repro / verification

Added `tests/api/test_multi_transformer_is_cached.py`, which calls `enable_cache` on
two independent transformer-only `BlockAdapter`s (mirroring what a dual-DiT model
does) and asserts the second one gets its own context manager.

- Against current `main`: fails with
  ```
  AssertionError
  ...cache_adapter.py:439: in collect_unified_blocks
      assert hasattr(block_adapter.pipe, "_context_manager")
  ```
  preceded by the log line `Pipeline has been already cached, skip creating cache context again.` for the second transformer -- confirming the class-level flag leaked from the first.
- With this fix applied: passes, and the second transformer has its own distinct `_context_manager`.

## Notes

Found while integrating a dual-DiT pipeline (video + audio branches, each wrapped
via the transformer-only API) with cache-dit.