### PR TITLE
feat: add extra_parallel_kwargs for model-specific CP options

### DIFF
--- a/src/cache_dit/distributed/async_ulysses/flux.py
+++ b/src/cache_dit/distributed/async_ulysses/flux.py
@@ -117,7 +117,8 @@ class FluxAsyncUlyssesPlanner(AsyncUlyssesPlanner):
       image_rotary_emb: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return FluxAsyncUlyssesPlanner._async_ulysses_attn_flux(
           self,
           attn,

--- a/src/cache_dit/distributed/async_ulysses/flux2.py
+++ b/src/cache_dit/distributed/async_ulysses/flux2.py
@@ -170,7 +170,8 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
                 attention_mask=None,
                 image_rotary_emb=None):
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return Flux2AsyncUlyssesPlanner._async_ulysses_attn_flux2(
           self,
           attn,
@@ -196,7 +197,8 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
     @functools.wraps(original)
     def wrapper(self, attn, hidden_states, attention_mask=None, image_rotary_emb=None):
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return Flux2AsyncUlyssesPlanner._async_ulysses_self_attn_flux2(
           self,
           attn,

--- a/src/cache_dit/distributed/async_ulysses/flux2.py
+++ b/src/cache_dit/distributed/async_ulysses/flux2.py
@@ -17,6 +17,30 @@ from ..core import _All2AllComm
 __all__ = ["Flux2AsyncUlyssesPlanner"]
 
 
+class _AsyncA2A:
+  """Eager-boundary wrapper around ``_All2AllComm``.
+
+  Comm construction, a2a launches and waits stay out of compiled graphs
+  (opaque calls that do not graph-break), mirroring fast-boogu's async
+  launcher pattern; the projections / norms / rope around them remain
+  traceable. Without this, the comm-induced graph break pushes the fp8
+  Linear calls into nested resume frames where torchao's tensor-subclass
+  ``__torch_function__`` dispatch crashes dynamo.
+  """
+
+  @torch.compiler.disable
+  def __init__(self, cp_config):
+    self.comm = _All2AllComm(cp_config)
+
+  @torch.compiler.disable
+  def launch(self, tensor, op):
+    return getattr(self.comm, op)(tensor)
+
+  @torch.compiler.disable
+  def wait(self, handle):
+    return handle.wait()
+
+
 @AsyncUlyssesRegistry.register("Flux2Transformer2DModel")
 class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
 
@@ -45,8 +69,8 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
       encoder_value = encoder_value.unflatten(-1, (attn.heads, -1))
       value = torch.cat([encoder_value, value], dim=1)
 
-    comm = _All2AllComm(cp_config)
-    value_wait = comm.send_v(value)
+    comm = _AsyncA2A(cp_config)
+    value_wait = comm.launch(value, "send_v")
 
     query = attn.to_q(hidden_states)
     query = query.unflatten(-1, (attn.heads, -1))
@@ -58,7 +82,7 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
       query = torch.cat([encoder_query, query], dim=1)
     if image_rotary_emb is not None:
       query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
-    query_wait = comm.send_q(query)
+    query_wait = comm.launch(query, "send_q")
 
     key = attn.to_k(hidden_states)
     key = key.unflatten(-1, (attn.heads, -1))
@@ -70,11 +94,11 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
       key = torch.cat([encoder_key, key], dim=1)
     if image_rotary_emb is not None:
       key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
-    key_wait = comm.send_k(key)
+    key_wait = comm.launch(key, "send_k")
 
-    value = value_wait.wait()
-    query = query_wait.wait()
-    key = key_wait.wait()
+    value = comm.wait(value_wait)
+    query = comm.wait(query_wait)
+    key = comm.wait(key_wait)
 
     out = _dispatch_attention_fn(
       query,
@@ -84,8 +108,8 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
       backend=self._attention_backend,
       cp_config=None,
     )
-    out_wait = comm.send_o(out)
-    out = out_wait.wait()
+    out_wait = comm.launch(out, "send_o")
+    out = comm.wait(out_wait)
 
     hidden_states = out.flatten(2, 3)
     hidden_states = hidden_states.to(query.dtype)
@@ -123,24 +147,24 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
     query, key, value = qkv.chunk(3, dim=-1)
 
     value = value.unflatten(-1, (attn.heads, -1))
-    comm = _All2AllComm(cp_config)
-    value_wait = comm.send_v(value)
+    comm = _AsyncA2A(cp_config)
+    value_wait = comm.launch(value, "send_v")
 
     query = query.unflatten(-1, (attn.heads, -1))
     query = attn.norm_q(query)
     if image_rotary_emb is not None:
       query = apply_rotary_emb(query, image_rotary_emb, sequence_dim=1)
-    query_wait = comm.send_q(query)
+    query_wait = comm.launch(query, "send_q")
 
     key = key.unflatten(-1, (attn.heads, -1))
     key = attn.norm_k(key)
     if image_rotary_emb is not None:
       key = apply_rotary_emb(key, image_rotary_emb, sequence_dim=1)
-    key_wait = comm.send_k(key)
+    key_wait = comm.launch(key, "send_k")
 
-    value = value_wait.wait()
-    query = query_wait.wait()
-    key = key_wait.wait()
+    value = comm.wait(value_wait)
+    query = comm.wait(query_wait)
+    key = comm.wait(key_wait)
 
     out = _dispatch_attention_fn(
       query,
@@ -150,10 +174,9 @@ class Flux2AsyncUlyssesPlanner(AsyncUlyssesPlanner):
       backend=self._attention_backend,
       cp_config=None,
     )
-    out_wait = comm.send_o(out)
+    out_wait = comm.launch(out, "send_o")
     mlp_hidden_states = attn.mlp_act_fn(mlp_hidden_states)
-    out = out_wait.wait()
-
+    out = comm.wait(out_wait)
     hidden_states = out.flatten(2, 3)
     hidden_states = hidden_states.to(query.dtype)
     hidden_states = torch.cat([hidden_states, mlp_hidden_states], dim=-1)

--- a/src/cache_dit/distributed/async_ulysses/longcat_image.py
+++ b/src/cache_dit/distributed/async_ulysses/longcat_image.py
@@ -121,7 +121,8 @@ if _longcat_available:
                   attention_mask=None,
                   image_rotary_emb=None):
         cp_config = getattr(self, "_cp_config", None)
-        if cp_config is not None and cp_config.ulysses_degree > 1:
+        if (cp_config is not None and cp_config.ulysses_degree > 1
+            and getattr(cp_config, "ulysses_async", False)):
           return LongCatImageAsyncUlyssesPlanner._async_ulysses_attn_longcat(
             self,
             attn,

--- a/src/cache_dit/distributed/async_ulysses/ovis_image.py
+++ b/src/cache_dit/distributed/async_ulysses/ovis_image.py
@@ -121,7 +121,8 @@ if _ovis_available:
                   attention_mask=None,
                   image_rotary_emb=None):
         cp_config = getattr(self, "_cp_config", None)
-        if cp_config is not None and cp_config.ulysses_degree > 1:
+        if (cp_config is not None and cp_config.ulysses_degree > 1
+            and getattr(cp_config, "ulysses_async", False)):
           return OvisImageAsyncUlyssesPlanner._async_ulysses_attn_ovis(
             self,
             attn,

--- a/src/cache_dit/distributed/async_ulysses/qwen_image.py
+++ b/src/cache_dit/distributed/async_ulysses/qwen_image.py
@@ -120,7 +120,8 @@ class QwenImageAsyncUlyssesPlanner(AsyncUlyssesPlanner):
                 attention_mask=None,
                 image_rotary_emb=None):
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return QwenImageAsyncUlyssesPlanner._async_ulysses_attn_qwen(
           self,
           attn,

--- a/src/cache_dit/distributed/async_ulysses/zimage.py
+++ b/src/cache_dit/distributed/async_ulysses/zimage.py
@@ -101,7 +101,8 @@ class ZImageAsyncUlyssesPlanner(AsyncUlyssesPlanner):
                 attention_mask=None,
                 freqs_cis=None):
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return ZImageAsyncUlyssesPlanner._async_ulysses_attn_zimage(
           self,
           attn,

--- a/src/cache_dit/distributed/async_ulysses/zimage_controlnet.py
+++ b/src/cache_dit/distributed/async_ulysses/zimage_controlnet.py
@@ -102,7 +102,8 @@ class ZImageControlNetAsyncUlyssesPlanner(AsyncUlyssesPlanner):
                 attention_mask=None,
                 freqs_cis=None):
       cp_config = getattr(self, "_cp_config", None)
-      if cp_config is not None and cp_config.ulysses_degree > 1:
+      if (cp_config is not None and cp_config.ulysses_degree > 1
+          and getattr(cp_config, "ulysses_async", False)):
         return ZImageControlNetAsyncUlyssesPlanner._async_ulysses_attn_zimage_controlnet(
           self,
           attn,

--- a/src/cache_dit/distributed/config.py
+++ b/src/cache_dit/distributed/config.py
@@ -109,6 +109,14 @@ class ParallelismConfig:
   #   Whether to enable the ulysses async attention to overlap
   #   communication and computation.
   ulysses_async: Optional[bool] = False
+  # extra_parallel_kwargs: (`Dict[str, Any]`, *optional*):
+  #   Extra model-specific options forwarded to downstream CP planners and
+  #   attention patches via ``_ContextParallelConfig.extra_kwargs``. Unlike the
+  #   deprecated ``parallel_kwargs`` (which maps to ParallelismConfig fields),
+  #   these keys are opaque to cache-dit, e.g.,
+  #   {"boogu_double_stream_cp": False} to opt out of the Boogu double-stream
+  #   CP wrapper (on by default).
+  extra_parallel_kwargs: Dict[str, Any] = dataclasses.field(default_factory=dict)
   # ring_rotate_method: (`str`, *optional*):
   #   The ring rotate method, default is `p2p`:
   #   'p2p': Use batch_isend_irecv ops to rotate the key and value tensors.

--- a/src/cache_dit/distributed/controlnets/dispatch.py
+++ b/src/cache_dit/distributed/controlnets/dispatch.py
@@ -52,6 +52,7 @@ def _parallelize_controlnet_cp(
       ulysses_anything=parallelism_config.ulysses_anything,
       ulysses_float8=parallelism_config.ulysses_float8,
       ulysses_async=parallelism_config.ulysses_async,
+      extra_kwargs=dict(parallelism_config.extra_parallel_kwargs),
     )
 
     cp_plan = parallelism_config.cp_plan

--- a/src/cache_dit/distributed/transformers/dispatch.py
+++ b/src/cache_dit/distributed/transformers/dispatch.py
@@ -70,6 +70,7 @@ def _parallelize_transformer_context(
       ulysses_anything=parallelism_config.ulysses_anything,
       ulysses_float8=parallelism_config.ulysses_float8,
       ulysses_async=parallelism_config.ulysses_async,
+      extra_kwargs=dict(parallelism_config.extra_parallel_kwargs),
     )
     if parallelism_config.hybrid_enabled():
       cp_config.setup(


### PR DESCRIPTION
ParallelismConfig gains an extra_parallel_kwargs dict (distinct from the deprecated parallel_kwargs, which maps to standard config fields). Its entries are opaque to cache-dit and forwarded to
_ContextParallelConfig.extra_kwargs on both transformer and controlnet dispatch, letting downstream model hooks read custom toggles, e.g. {"boogu_double_stream_cp": False} to opt out of fast-boogu's default-on double-stream CP wrapper.