### PR TITLE
fix(metrics): import compute_reward_score so `image_reward` stops raising NameError

### DIFF
--- a/src/cache_dit/metrics/metrics.py
+++ b/src/cache_dit/metrics/metrics.py
@@ -22,7 +22,7 @@ compute_fid = _safe_import(".fid", "compute_fid")
 compute_video_fid = _safe_import(".fid", "compute_video_fid")
 compute_lpips_img = _safe_import(".metrics", "compute_lpips_img")
 compute_clip_score = _safe_import(".clip_score", "compute_clip_score")
-compute_reward_score_img = _safe_import(".image_reward", "compute_reward_score_img")
+compute_reward_score = _safe_import(".image_reward", "compute_reward_score")
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
## Problem

`cache-dit-metrics-cli image_reward ...` can never succeed — it dies with a `NameError` before it reaches any model code.

`src/cache_dit/metrics/metrics.py` binds the **per-image** helper, but the only call site unpacks the **directory-level** function, which is never imported:

```python
# metrics.py:24-25
compute_clip_score       = _safe_import(".clip_score",   "compute_clip_score")
compute_reward_score_img = _safe_import(".image_reward", "compute_reward_score_img")

# metrics.py:659-663
if metric == "clip_score":
    clip_score, n = compute_clip_score(img_test, prompt_true)      # ok
    _logging_msg(clip_score, "clip_score", n)
if metric == "image_reward":
    image_reward, n = compute_reward_score(img_test, prompt_true)  # NameError
    _logging_msg(image_reward, "image_reward", n)
```

`compute_reward_score` is not defined in this module, and the name that *is* bound — `compute_reward_score_img` — is referenced nowhere in the tree (`grep -rn compute_reward_score_img` returns only line 25).

`setup.cfg`'s flake8 `ignore` list contains `F821`, so the undefined name never showed up in CI.

## Fix

Bind the same shape the working `clip_score` sibling uses — one line, no behaviour change anywhere else:

```diff
-compute_reward_score_img = _safe_import(".image_reward", "compute_reward_score_img")
+compute_reward_score = _safe_import(".image_reward", "compute_reward_score")
```

This is not just a naming slip: the two functions have different contracts, and only the dir-level one fits the call site.

| name | signature | returns | fits `a, n = f(...)`? |
|---|---|---|---|
| `compute_reward_score` (dir) | `(img_dir, prompts, imagereward_model_path=None)` | `Tuple[float, int]` | ✅ |
| `compute_reward_score_img` (per-image) | `(img, prompt, imagereward_model_path=None)` | `float` | ❌ `TypeError` on unpack |

For reference, `clip_score.py` exposes the exact same pair (`compute_clip_score` / `compute_clip_score_img`) and `metrics.py` already imports the dir-level one there.

## Verification

Ran the real CLI entrypoint against a throwaway image dir + prompt file (only the unrelated third-party `diffusers` / `ImageReward` imports are stubbed on this box; all `cache_dit` code is the unmodified repo source).

**Before**

```
compute_clip_score       -> <function compute_clip_score>
compute_reward_score_img -> <function import_error_metric_func>
compute_reward_score     -> <MISSING>
RESULT: NameError: name 'compute_reward_score' is not defined
        raised at metrics.py:662 | image_reward, n = compute_reward_score(img_test, prompt_true)
```

**After**

```
compute_clip_score       -> <function compute_clip_score>
compute_reward_score_img -> <MISSING>
compute_reward_score     -> <function import_error_metric_func>
RESULT: ImportError: This metric function requires additional dependencies that are
        not installed. Please check the documentation for installation instructions.
```

i.e. the call now resolves and reaches `_safe_import`'s intended, actionable error for a
missing optional dep instead of a bare `NameError`. With `ImageReward` importable, the
name binds to the real dir-level function whose signature matches `compute_clip_score`'s
one-for-one:

```
metrics.compute_clip_score   -> cache_dit.metrics.clip_score.compute_clip_score
    (img_dir, prompts, clip_model_path=None) -> Union[Tuple[float, int], Tuple[None, None]]
metrics.compute_reward_score -> cache_dit.metrics.image_reward.compute_reward_score
    (img_dir, prompts, imagereward_model_path=None) -> Union[Tuple[float, int], Tuple[None, None]]
```

Lint (pinned to the versions in `.pre-commit-config.yaml`):

- `yapf==0.40.2 --diff src/cache_dit/metrics/metrics.py` → no diff
- `flake8==7.1.1 --config=setup.cfg` → unchanged from `main` (only pre-existing `D1xx` docstring notices)
- `python -m pyflakes src/` → no `undefined name` remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)
