### PR TITLE
fix(cache): restart continuous cache streak after compute steps

### DIFF
--- a/src/cache_dit/caching/cache_contexts/cache_context.py
+++ b/src/cache_dit/caching/cache_contexts/cache_context.py
@@ -249,28 +249,18 @@ class CachedContext:
   def add_cached_step(self):
     curr_cached_step = self.get_current_step()
     if not self.is_separate_cfg_step():
-      if self.cached_steps:
-        prev_cached_step = self.cached_steps[-1]
-        if curr_cached_step - prev_cached_step == 1:
-          if self.continuous_cached_steps == 0:
-            self.continuous_cached_steps += 2
-          else:
-            self.continuous_cached_steps += 1
-      else:
+      if self.cached_steps and curr_cached_step - self.cached_steps[-1] == 1:
         self.continuous_cached_steps += 1
+      else:
+        self.continuous_cached_steps = 1
 
       self.cached_steps.append(curr_cached_step)
       self.accumulated_cached_steps += 1
     else:
-      if self.cfg_cached_steps:
-        prev_cfg_cached_step = self.cfg_cached_steps[-1]
-        if curr_cached_step - prev_cfg_cached_step == 1:
-          if self.cfg_continuous_cached_steps == 0:
-            self.cfg_continuous_cached_steps += 2
-          else:
-            self.cfg_continuous_cached_steps += 1
-      else:
+      if self.cfg_cached_steps and curr_cached_step - self.cfg_cached_steps[-1] == 1:
         self.cfg_continuous_cached_steps += 1
+      else:
+        self.cfg_continuous_cached_steps = 1
 
       self.cfg_cached_steps.append(curr_cached_step)
       self.cfg_accumulated_cached_steps += 1

--- a/tests/api/test_refresh_context.py
+++ b/tests/api/test_refresh_context.py
@@ -3,6 +3,7 @@ import pytest
 import torch
 import cache_dit
 from cache_dit import ForwardPattern, BlockAdapter, DBCacheConfig
+from cache_dit.caching.cache_contexts.cache_manager import CachedContextManager
 from cache_dit.platforms import current_platform
 from utils import RandPipeline
 
@@ -19,6 +20,49 @@ PATTERNS = [
 
 DTYPES = ([torch.float32]
           if not current_platform.is_accelerator_available() else [torch.float32, torch.bfloat16])
+
+
+@pytest.mark.parametrize(
+  "enable_separate_cfg,cfg_compute_first",
+  [
+    (False, False),
+    (True, False),
+    (True, True),
+  ],
+)
+def test_continuous_cache_limit_restarts_after_compute_step(
+  enable_separate_cfg,
+  cfg_compute_first,
+):
+  config = DBCacheConfig(
+    max_warmup_steps=4,
+    max_continuous_cached_steps=1,
+    residual_diff_threshold=0.06,
+    enable_separate_cfg=enable_separate_cfg,
+    cfg_compute_first=cfg_compute_first,
+    cfg_diff_compute_separate=not cfg_compute_first,
+  )
+  manager = CachedContextManager()
+  context = manager.new_context(cache_config=config)
+  manager.set_context(context)
+  cached_steps = {False: [], True: []}
+
+  num_forwards = 19 * (2 if enable_separate_cfg else 1)
+  for _ in range(num_forwards):
+    manager.mark_step_begin()
+    residual = manager.get_Fn_buffer()
+    if residual is None:
+      residual = torch.ones(1)
+
+    if manager.can_cache(residual):
+      manager.add_cached_step()
+      cached_steps[manager.is_separate_cfg_step()].append(manager.get_current_step())
+    else:
+      manager.set_Fn_buffer(residual)
+
+  expected = list(range(4, 19, 2))
+  assert cached_steps[False] == expected
+  assert cached_steps[True] == (expected if enable_separate_cfg else [])
 
 
 @pytest.mark.parametrize("device", DEVICES)


### PR DESCRIPTION
## Summary

- restart the continuous cache streak at one after a non-adjacent cache hit
- apply the same accounting to normal and separate-CFG branches
- add regression coverage for both CFG execution orders

## Problem

When `max_continuous_cached_steps=1` blocks a cache hit, `can_cache()` resets the streak counter to zero. The next non-adjacent hit was appended without setting the counter back to one, so the following adjacent step was also allowed.

With four warmup steps and 19 denoising steps, the buggy sequence was `[4, 6, 7, 9, 10, 12, 13, 15, 16, 18]`; the limit should produce `[4, 6, 8, 10, 12, 14, 16, 18]`.

## Test plan

- `pytest tests/api/test_refresh_context.py -q` (9 passed)
- `pre-commit run --files src/cache_dit/caching/cache_contexts/cache_context.py tests/api/test_refresh_context.py`